### PR TITLE
Fixing unassignment of ocean-mask in topography smoothing

### DIFF
--- a/src/atmos_spectral/init/spectral_init_cond.F90
+++ b/src/atmos_spectral/init/spectral_init_cond.F90
@@ -218,8 +218,12 @@ else if(trim(topography_option) == 'input') then
      call error_mesg('get_topography','topography_option="'//trim(topography_option)//'"'// &
                      ' but '//trim('INPUT/'//topog_file_name)//' does not exist', FATAL)
    endif
-
-   where(land_ones < 1.) ocean_mask = .true.
+    
+   where(land_ones > 0.)
+     ocean_mask = .false.
+   elsewhere
+     ocean_mask = .true.
+   end where
 
    surf_geopotential = grav*surf_height
 


### PR DESCRIPTION
This unassignment had caused the topography smoothing to give different answers on different numbers of cores, and also meant that the zonally-symmetric pull request (a905b5a) changed the topography smoothing answer when it really should not have done. With this change, the `ocean_mask` array is fully assigned, and the topography smoothing gives the same answer on different #'s of cores, and the same as the commits pre and post the zonally-symmetric p/r when they were run on 1 core (which is the only time these two commits gave the same answer). 

Also, I have changed the way the `ocean_mask` is defined, with areas of ocean being those where `land_ones =0.`, whereas previously the mask defined areas of ocean as those where `land_ones<1.`. With a binary land-mask of 1s and 0s, this makes no difference. But when land-masks with fractional land-coverage are used, this is an important distinction. I have changed it to be in line with the land-mask definition in `idealized_moist_phys.F90`, so that no possible land-mask conflicts are possible.

*N.B. that all simulations with topography smoothing will give a different answer after this commit to what they did before it. But this answer will also be different to the answer given before a905b5a. However, topography smoothing is now performed correctly, so future runs with topography smoothing should use this commit or later.*