### PR TITLE
Release v1 bucket depth

### DIFF
--- a/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
+++ b/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
@@ -127,9 +127,9 @@ character(len=256) :: land_field_name = 'land_mask'
 ! RG Add bucket
 logical :: bucket = .false. 
 integer :: future
-real :: init_bucket_depth = 20. ! default initial bucket depth in m LJJ
+real :: init_bucket_depth = 1000. ! default large value
 real :: init_bucket_depth_land = 20. 
-real :: max_bucket_depth_land = 1000. ! default large value
+real :: max_bucket_depth_land = 0.15 ! default from Manabe 1969
 real :: robert_bucket = 0.04   ! default robert coefficient for bucket depth LJJ
 real :: raw_bucket = 0.53       ! default raw coefficient for bucket depth LJJ
 ! end RG Add bucket

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -525,7 +525,10 @@ subroutine surface_flux_1d (                                           &
 	  where (avail)
 	      ! begin LJJ addition
   		where(land)
-            flux_q    =  (bucket_depth/max_bucket_depth_land) * rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
+			where (bucket_depth >= max_bucket_depth_land*0.75)
+				flux_q    =  rho_drag * (q_surf0 - q_atm)
+			elsewhere	
+                flux_q    =  bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
 		elsewhere
 	        flux_q    =  rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
 		end where
@@ -544,7 +547,10 @@ subroutine surface_flux_1d (                                           &
 	      dedq_surf = 0.
 	      dedq_atm = -rho_drag ! d(latent heat flux)/d(atmospheric mixing ratio)
 		  where(land)
- 	          dedt_surf =  (bucket_depth/max_bucket_depth_land) * rho_drag * (q_sat1 - q_sat) *del_temp_inv
+			  where (bucket_depth >= max_bucket_depth_land*0.75)
+				  dedt_surf =  rho_drag * (q_sat1 - q_sat) *del_temp_inv
+			  elsewhere
+      	          dedt_surf =  bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_sat1 - q_sat) *del_temp_inv
 		  elsewhere
  	          dedt_surf =  rho_drag * (q_sat1 - q_sat) *del_temp_inv
 		  end where

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -529,6 +529,7 @@ subroutine surface_flux_1d (                                           &
 				flux_q    =  rho_drag * (q_surf0 - q_atm)
 			elsewhere	
                 flux_q    =  bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
+			end where
 		elsewhere
 	        flux_q    =  rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
 		end where
@@ -551,6 +552,7 @@ subroutine surface_flux_1d (                                           &
 				  dedt_surf =  rho_drag * (q_sat1 - q_sat) *del_temp_inv
 			  elsewhere
       	          dedt_surf =  bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_sat1 - q_sat) *del_temp_inv
+			  end where
 		  elsewhere
  	          dedt_surf =  rho_drag * (q_sat1 - q_sat) *del_temp_inv
 		  end where


### PR DESCRIPTION
Identical to the previous bucket pull request, except for using release-v1-bucket_depth instead of bucket_depth_II. release-v1-bucket_depth is based around release-v1 but fast forwarded to include changes from pull requests 13-15. If needed, the commit associated with the merge of this pull request can therefore be applied to release-v1 without also copying over the development to the python libraries.