### PR TITLE
A few compile and git changes to make code more portable

### DIFF
--- a/postprocessing/compile_mppn.sh
+++ b/postprocessing/compile_mppn.sh
@@ -11,18 +11,18 @@ ppdir=./                 # path to directory containing the tool for combining d
 
 # 2. Load the necessary tools into the environment
 module purge
-module load netcdf-4.3.0-openmpi-intel
+source $GFDL_BASE/src/extra/env/$GFDL_ENV
 module list
 netcdf_flags=`nf-config --fflags --flibs`
 #--------------------------------------------------------------------------------------------------------
 # compile combine tool
 #cd $ppdir
-cc -O -c `nf-config --cflags` mppnccombine.c
+$CC -O -c `nf-config --cflags` mppnccombine.c
 if [ $? != 0 ]; then
     echo "ERROR: could not compile combine tool"
     exit 1
 fi
-cc -O -o mppnccombine.x `nf-config --libs`  mppnccombine.o
+$CC -O -o mppnccombine.x `nf-config --fflags --flibs`  mppnccombine.o
 if [ $? != 0 ]; then
     echo "ERROR: could not compile combine tool"
     exit 1

--- a/postprocessing/mppnccombine_run.sh
+++ b/postprocessing/mppnccombine_run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# 1. Load the necessary tools into the environment
+module purge
+source $GFDL_BASE/src/extra/env/$GFDL_ENV
+module list
+
+# Run with input file as input taken from BASH script
+echo ${1}
+${1}/mppnccombine.x ${2}

--- a/postprocessing/mppnccombine_run.sh
+++ b/postprocessing/mppnccombine_run.sh
@@ -7,4 +7,4 @@ module list
 
 # Run with input file as input taken from BASH script
 echo ${1}
-${1}/mppnccombine.x ${2}
+exec ${1}/mppnccombine.x ${2}

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -262,6 +262,7 @@ logical :: raoult_sat_vap        = .false.
 logical :: do_simple             = .false.
 
 real    :: land_humidity_prefactor  =  1.0    !s Default is that land makes no difference to evaporative fluxes
+real    :: land_humidity_prefactor_a  =  1.0
 
 real    :: flux_heat_gp  =  5.7    !s Default value for Jupiter of 5.7 Wm^-2
 real    :: diabatic_acce =  1.0    !s Diabatic acceleration??
@@ -279,6 +280,7 @@ namelist /surface_flux_nml/ no_neg_q,             &
                             raoult_sat_vap,       &
                             do_simple,            &
                             land_humidity_prefactor, & !s Added to make land 'dry', i.e. to decrease the evaporative heat flux in areas of land.
+                            land_humidity_prefactor_a, &
                             flux_heat_gp,         &    !s prescribed lower boundary heat flux on a giant planet
 			    diabatic_acce
 
@@ -565,9 +567,9 @@ subroutine surface_flux_1d (                                           &
   where (avail)
      where (land)
 !s      Simplified land model uses simple prefactor in front of qsurf0. Land is therefore basically the same as sea, but with this prefactor, hence the changes to dedq_surf and dedt_surf also.
-        flux_q    =  rho_drag * (land_humidity_prefactor*q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
+        flux_q    =  rho_drag * land_humidity_prefactor_a *(land_humidity_prefactor*q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
         dedq_surf = 0
-        dedt_surf =  rho_drag * (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
+        dedt_surf =  rho_drag * land_humidity_prefactor_a * (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
 !        dedq_surf = rho_drag
 !        dedt_surf = 0
      elsewhere

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -262,7 +262,6 @@ logical :: raoult_sat_vap        = .false.
 logical :: do_simple             = .false.
 
 real    :: land_humidity_prefactor  =  1.0    !s Default is that land makes no difference to evaporative fluxes
-real    :: land_humidity_prefactor_a  =  1.0
 
 real    :: flux_heat_gp  =  5.7    !s Default value for Jupiter of 5.7 Wm^-2
 real    :: diabatic_acce =  1.0    !s Diabatic acceleration??
@@ -280,7 +279,6 @@ namelist /surface_flux_nml/ no_neg_q,             &
                             raoult_sat_vap,       &
                             do_simple,            &
                             land_humidity_prefactor, & !s Added to make land 'dry', i.e. to decrease the evaporative heat flux in areas of land.
-                            land_humidity_prefactor_a, &
                             flux_heat_gp,         &    !s prescribed lower boundary heat flux on a giant planet
 			    diabatic_acce
 
@@ -567,9 +565,9 @@ subroutine surface_flux_1d (                                           &
   where (avail)
      where (land)
 !s      Simplified land model uses simple prefactor in front of qsurf0. Land is therefore basically the same as sea, but with this prefactor, hence the changes to dedq_surf and dedt_surf also.
-        flux_q    =  rho_drag * land_humidity_prefactor_a *(land_humidity_prefactor*q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
+        flux_q    =  rho_drag * (land_humidity_prefactor*q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
         dedq_surf = 0
-        dedt_surf =  rho_drag * land_humidity_prefactor_a * (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
+        dedt_surf =  rho_drag *  (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
 !        dedq_surf = rho_drag
 !        dedt_surf = 0
      elsewhere

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -567,7 +567,7 @@ subroutine surface_flux_1d (                                           &
 !s      Simplified land model uses simple prefactor in front of qsurf0. Land is therefore basically the same as sea, but with this prefactor, hence the changes to dedq_surf and dedt_surf also.
         flux_q    =  rho_drag * (land_humidity_prefactor*q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
         dedq_surf = 0
-        dedt_surf =  rho_drag *  (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
+        dedt_surf =  rho_drag * (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
 !        dedq_surf = rho_drag
 !        dedt_surf = 0
      elsewhere

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -129,8 +129,15 @@ class CodeBase(Logger):
 
     def write_source_control_status(self, outfile):
         """Write the current state of the source code to a file."""
-
-        gfdl_git = git.bake('-C', GFDL_BASE)
+        
+        try:
+            gfdl_git = git.bake('-C', GFDL_BASE)        
+            git_test = gfdl_git.log('-1', '--format="%H"').stdout
+        except:
+            gfdl_git = git.bake('--git-dir', GFDL_BASE+'.git', '--work-tree', GFDL_BASE)
+            git_test = gfdl_git.log('-1', '--format="%H"').stdout
+                        
+        
         with open(outfile, 'w') as file:
             # write out the git commit id of the compiled source code
             file.write("*---commit hash used for fortran code in workdir---*:\n")

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -82,7 +82,7 @@ class CodeBase(Logger):
         self.executable_fullpath = P(self.builddir, self.executable_name)
 
         # alias a version of git acting from within the code directory
-        self.git = git_run_in_directory(self.codedir)
+        self.git = git_run_in_directory(GFDL_BASE, self.codedir)
 
         # check if the code is available.  If it's not, checkout the repo.
         if not self.code_is_available:
@@ -130,7 +130,7 @@ class CodeBase(Logger):
     def write_source_control_status(self, outfile):
         """Write the current state of the source code to a file."""
 
-        gfdl_git = git_run_in_directory(GFDL_BASE)                              
+        gfdl_git = git_run_in_directory(GFDL_BASE, GFDL_BASE)                              
         
         with open(outfile, 'w') as file:
             # write out the git commit id of the compiled source code

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -7,7 +7,7 @@ import sh
 
 from isca import GFDL_WORK, GFDL_BASE, _module_directory, get_env_file
 from .loghandler import Logger
-from .helpers import url_to_folder, destructive, useworkdir, mkdir, cd, git, P
+from .helpers import url_to_folder, destructive, useworkdir, mkdir, cd, git, P, git_run_in_directory
 
 
 class CodeBase(Logger):
@@ -82,14 +82,7 @@ class CodeBase(Logger):
         self.executable_fullpath = P(self.builddir, self.executable_name)
 
         # alias a version of git acting from within the code directory
-        try:
-            codedir_git = git.bake('-C', self.codedir)        
-            git_test = codedir_git.log('-1', '--format="%H"').stdout
-            self.git = git.bake('-C', self.codedir)
-        except:
-            codedir_git = git.bake('--git-dir='+self.codedir+'/.git', '--work-tree='+self.codedir)
-            git_test = codedir_git.log('-1', '--format="%H"').stdout
-            self.git = git.bake('--git-dir='+self.codedir+'/.git', '--work-tree='+self.codedir)
+        self.git = git_run_in_directory(self.codedir)
 
         # check if the code is available.  If it's not, checkout the repo.
         if not self.code_is_available:
@@ -136,14 +129,8 @@ class CodeBase(Logger):
 
     def write_source_control_status(self, outfile):
         """Write the current state of the source code to a file."""
-        
-        try:
-            gfdl_git = git.bake('-C', GFDL_BASE)        
-            git_test = gfdl_git.log('-1', '--format="%H"').stdout
-        except:
-            gfdl_git = git.bake('--git-dir='+GFDL_BASE+'/.git', '--work-tree='+GFDL_BASE)
-            git_test = gfdl_git.log('-1', '--format="%H"').stdout
-                        
+
+        gfdl_git = git_run_in_directory(GFDL_BASE)                              
         
         with open(outfile, 'w') as file:
             # write out the git commit id of the compiled source code

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -82,7 +82,14 @@ class CodeBase(Logger):
         self.executable_fullpath = P(self.builddir, self.executable_name)
 
         # alias a version of git acting from within the code directory
-        self.git = git.bake('-C', self.codedir)
+        try:
+            codedir_git = git.bake('-C', self.codedir)        
+            git_test = codedir_git.log('-1', '--format="%H"').stdout
+            self.git = git.bake('-C', self.codedir)
+        except:
+            codedir_git = git.bake('--git-dir=', self.codedir+'.git', '--work-tree=', self.codedir)
+            git_test = codedir_git.log('-1', '--format="%H"').stdout
+            self.git = git.bake('--git-dir=', self.codedir+'.git', '--work-tree=', self.codedir)
 
         # check if the code is available.  If it's not, checkout the repo.
         if not self.code_is_available:

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -87,9 +87,9 @@ class CodeBase(Logger):
             git_test = codedir_git.log('-1', '--format="%H"').stdout
             self.git = git.bake('-C', self.codedir)
         except:
-            codedir_git = git.bake('--git-dir=', self.codedir+'.git', '--work-tree=', self.codedir)
+            codedir_git = git.bake('--git-dir='+self.codedir+'/.git', '--work-tree='+self.codedir)
             git_test = codedir_git.log('-1', '--format="%H"').stdout
-            self.git = git.bake('--git-dir=', self.codedir+'.git', '--work-tree=', self.codedir)
+            self.git = git.bake('--git-dir='+self.codedir+'/.git', '--work-tree='+self.codedir)
 
         # check if the code is available.  If it's not, checkout the repo.
         if not self.code_is_available:
@@ -141,7 +141,7 @@ class CodeBase(Logger):
             gfdl_git = git.bake('-C', GFDL_BASE)        
             git_test = gfdl_git.log('-1', '--format="%H"').stdout
         except:
-            gfdl_git = git.bake('--git-dir', GFDL_BASE+'.git', '--work-tree', GFDL_BASE)
+            gfdl_git = git.bake('--git-dir='+GFDL_BASE+'/.git', '--work-tree='+GFDL_BASE)
             git_test = gfdl_git.log('-1', '--format="%H"').stdout
                         
         

--- a/src/extra/python/isca/experiment.py
+++ b/src/extra/python/isca/experiment.py
@@ -269,11 +269,11 @@ class Experiment(Logger, EventEmitter):
 
         if num_cores > 1:
             # use postprocessing tool to combine the output from several cores
-            combinetool = sh.Command(P(self.codebase.builddir, 'mppnccombine.x'))
+            combinetool = sh.Command(P(self.codebase.builddir, 'mppnccombine_run.sh'))
             for file in self.diag_table.files:
                 netcdf_file = '%s.nc' % file
                 filebase = P(self.rundir, netcdf_file)
-                combinetool(filebase)
+                combinetool(self.codebase.builddir, filebase)
                 # copy the combined netcdf file into the data archive directory
                 sh.cp(filebase, P(outdir, netcdf_file))
                 # remove all netcdf fragments from the run directory

--- a/src/extra/python/isca/experiment.py
+++ b/src/extra/python/isca/experiment.py
@@ -172,7 +172,7 @@ class Experiment(Logger, EventEmitter):
 
     @destructive
     @useworkdir
-    def run(self, i, restart_file=None, use_restart=True, num_cores=8, overwrite_data=False, save_run=False, run_idb=False, nice_score=0):
+    def run(self, i, restart_file=None, use_restart=True, multi_node=False, num_cores=8, overwrite_data=False, save_run=False, run_idb=False, nice_score=0):
         """Run the model.
             `num_cores`: Number of mpi cores to distribute over.
             `restart_file` (optional): A path to a valid restart archive.  If None and `use_restart=True`,
@@ -208,6 +208,11 @@ class Experiment(Logger, EventEmitter):
         for filename in self.inputfiles:
             sh.cp([filename, P(indir, os.path.split(filename)[1])])
 
+        mpirun_opts= ''
+
+        if multi_node:
+            mpirun_opts += ' -bootstrap pbsdsh -f $PBS_NODEFILE'
+
         if use_restart:
             if not restart_file:
                 # get the restart from previous iteration
@@ -228,6 +233,7 @@ class Experiment(Logger, EventEmitter):
             'execdir': self.codebase.builddir,
             'executable': self.codebase.executable_name,
             'env_source': self.env_source,
+            'mpirun_opts': mpirun_opts,
             'num_cores': num_cores,
             'run_idb': run_idb,
             'nice_score': nice_score

--- a/src/extra/python/isca/helpers.py
+++ b/src/extra/python/isca/helpers.py
@@ -58,19 +58,19 @@ def git_diff(directory):
     git_diff_output = str(git_diff_output).split("\n")
     return git_diff_output
 
-def git_run_in_directory(dir_in):
+def git_run_in_directory(GFDL_BASE_DIR, dir_in):
     """Function that bakes in git command to run in a specified directory.
        `Try except` is to catch different versions of this command
        in versions of git >1.8 (`git -C`) and older versions for which
        `git -C` is not a recognized command. """
        
     try:
-        codedir_git = git.bake('-C', dir_in)        
+        codedir_git = git.bake('-C', GFDL_BASE_DIR)        
         git_test = codedir_git.log('-1', '--format="%H"').stdout
         baked_git_fn = git.bake('-C', dir_in)
     except:
-        codedir_git = git.bake('--git-dir='+dir_in+'/.git', '--work-tree='+dir_in)
+        codedir_git = git.bake('--git-dir='+GFDL_BASE_DIR+'/.git', '--work-tree='+GFDL_BASE_DIR)
         git_test = codedir_git.log('-1', '--format="%H"').stdout
-        baked_git_fn = git.bake('--git-dir='+dir_in+'/.git', '--work-tree='+dir_in)
+        baked_git_fn = git.bake('--git-dir='+dir_in+'/.git', '--work-tree='+dir_in)        
         
     return baked_git_fn        

--- a/src/extra/python/isca/helpers.py
+++ b/src/extra/python/isca/helpers.py
@@ -58,3 +58,19 @@ def git_diff(directory):
     git_diff_output = str(git_diff_output).split("\n")
     return git_diff_output
 
+def git_run_in_directory(dir_in):
+    """Function that bakes in git command to run in a specified directory.
+       `Try except` is to catch different versions of this command
+       in versions of git >1.8 (`git -C`) and older versions for which
+       `git -C` is not a recognized command. """
+       
+    try:
+        codedir_git = git.bake('-C', dir_in)        
+        git_test = codedir_git.log('-1', '--format="%H"').stdout
+        baked_git_fn = git.bake('-C', dir_in)
+    except:
+        codedir_git = git.bake('--git-dir='+dir_in+'/.git', '--work-tree='+dir_in)
+        git_test = codedir_git.log('-1', '--format="%H"').stdout
+        baked_git_fn = git.bake('--git-dir='+dir_in+'/.git', '--work-tree='+dir_in)
+        
+    return baked_git_fn        

--- a/src/extra/python/isca/templates/compile.sh
+++ b/src/extra/python/isca/templates/compile.sh
@@ -41,6 +41,7 @@ if [ ! -e "{{ execdir }}/mppnccombine.x" ]; then
   # fi
 
   ln -s $ppdir/mppnccombine.x {{ execdir }}/mppnccombine.x
+  ln -s $ppdir/mppnccombine_run.sh {{ execdir }}/mppnccombine_run.sh
 fi
 
 cd $execdir

--- a/src/extra/python/isca/templates/run.sh
+++ b/src/extra/python/isca/templates/run.sh
@@ -21,7 +21,7 @@ if [ $debug == True ]; then
    echo "Opening idb for debugging"
    idb -gdb  {{ executable}}
 else
-  nice -{{nice_score}} mpirun  -np {{ num_cores }} {{ execdir }}/{{ executable }}
+  nice -{{nice_score}} mpirun {{mpirun_opts}} -np {{ num_cores }} {{ execdir }}/{{ executable }}
 fi
 
 err_code=$?


### PR DESCRIPTION
When running on Exeter's HPC I ran into a couple of problems:

* The `git -C` command used in `codebase.py` is only in git versions more recent than 1.8. So Exeter's HPC (which was running 1.8) failed on these commands.
* The `mppnccombine.x` compile script still wanted to load a emps-gv specific netcdf library, rather than the appropriate env file.

To fix these problems I've:
* Added a `try` `except` statement around the git commands and have added some git commands that do the same thing in previous versions of git.
* Added the relevant `source` statement to `compile_mppnccombine.sh`. This then uses the same libraries to compile `mppnccombine.x` as it does to compile the model. However, this means that these same modules need to be loaded when running `mppnccombine.x`. I've therefore written a short shell script that loads the modules and runs `mppnccombine.x`, and have added this to the python library. This means that a normal user with the correct libraries in their computer's `env` file should have the `mppnccombine.x` compilation and execution done without them noticing.
