### PR TITLE
Missing namelist-writes to logfile

### DIFF
--- a/src/shared/constants/constants.F90
+++ b/src/shared/constants/constants.F90
@@ -36,7 +36,9 @@ module constants_mod
 !   Constants are accessed through the "use" statement.
 ! </DESCRIPTION>
 
-use fms_mod,               only: open_file, check_nml_error, mpp_pe, close_file, write_version_number, error_mesg, NOTE
+use fms_mod,               only: open_file, check_nml_error, &
+                                 mpp_pe, mpp_root_pe, stdlog, &
+                                 close_file, write_version_number, error_mesg, NOTE
 
 implicit none
 private
@@ -289,6 +291,7 @@ subroutine constants_init
     enddo
     10 call close_file (unit)
 
+    if (mpp_pe() == mpp_root_pe()) write (stdlog(),nml=constants_nml)
 
     !> SECONDS_PER_SOL is the exoplanet equivalent of seconds_per_day.
     !! It is the number of seconds between sucessive solar zeniths at longitude 0.


### PR DESCRIPTION
This pull request is for adding missing namelist-writes to the logfile. Here is my best attempt at the list (which I've checked as far as it goes, but may be incomplete):

badType1_nml
badType2_nml
constants_nml
horiz_interp_spherical_nml
interpolator_nml
missingVar_nml
qflux_nml
test_axis_utils_nml
test_horiz_interp_nml
test_nml

Some of these may not matter. The one I was already aware of, constants_nml, is fixed by 
f48f4a4, which has been tested (once), and may serve as an example.

This pull request could be left open until they are all done (or all the ones that matter), or closed earlier for convenience. Even without closing the pull request, the branch could be merged into master at any time.