### PR TITLE
Qflux updates and plev.x compile script

### DIFF
--- a/postprocessing/plevel_interpolation/README
+++ b/postprocessing/plevel_interpolation/README
@@ -1,32 +1,6 @@
 Exeter instructions
 
-This set of scripts is able to take 3D data that is outputed on model sigma levels, and interpolate it to be on pressure levels. Basic instructions are as follows:
-
-cd postprocessing/plevel_interpolation/exec/
-
-source ../../../src/extra/loadmodule
-
-../bin/mkmf -p plev.x -t ../bin/mkmf.template.ia64 -c "-Duse_netCDF" -a ../src ../src/path_names ../src/shared/mpp/include ../src/shared/include
-
-make -f Makefile
-
-Once this is done the executable `plev.x` will be created in the exec folder.
-
-To execute the script, do
-
-cd ../scripts
-./plevel.sh INSERT OPTIONS HERE
-
-The runscript plevel.sh takes many different inputs, which are well documented in the file itself. A working example is
-
-./plevel.sh -i PATH_TO_FILE/atmos_daily.nc div height omega temp ucomp vcomp vor
-
-The -i option specifies the input netcdf file location. The variable names are those that you wish to interpolate. 
-
-The result is the file `plevel.nc` in postprocessing/plevel_interpolation/scripts 
-(the output file name can be changed in plevel.sh).
-
-plevel.nc will contain all of the 3D fields that have been interpolated. The pressure levels onto which the data is interpolated are set in plevel.sh and are in Pascal (not hecto pascal). 
+Use the `compile_plev_interpolation.sh` script in the `postprocessing` directory to compile plev.x. Then use `run_level.py` to run the interpolation.
 
 Known issues:
 

--- a/postprocessing/plevel_interpolation/compile_plev_interpolation.sh
+++ b/postprocessing/plevel_interpolation/compile_plev_interpolation.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#Script that compiles the plev.x executable
+
+cd ./exec
+
+source $GFDL_BASE/src/extra/env/$GFDL_ENV
+
+../bin/mkmf -p plev.x -t ../bin/mkmf.template.ia64 -c "-Duse_netCDF" -a ../src ../src/path_names ../src/shared/mpp/include ../src/shared/include
+
+make -f Makefile

--- a/src/atmos_spectral/driver/solo/mixed_layer.F90
+++ b/src/atmos_spectral/driver/solo/mixed_layer.F90
@@ -113,8 +113,8 @@ character(len=256) :: land_option = 'none'
 real,dimension(10) :: slandlon=0,slandlat=0,elandlon=-1,elandlat=-1
 !s End mj extra options
 
-character(len=256) :: qflux_file_name  = 'INPUT/ocean_qflux.nc'
-character(len=256) :: qflux_field_name = 'ocean_qflux'
+character(len=256) :: qflux_file_name  = 'ocean_qflux'
+character(len=256) :: qflux_field_name = 'ocean_qflux' !Only used when using a non-time-varying q-flux. Otherwise code assumes field_name = file_name. 
 
 character(len=256) :: ice_file_name  = 'siconc_clim_amip'
 real    :: ice_albedo_value = 0.7

--- a/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
+++ b/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
@@ -264,11 +264,11 @@ if __name__ == "__main__":
     input_dir=GFDL_BASE
     base_dir=GFDL_DATA
     land_file='input/era_land_t42.nc'
-    base_exp_name='bog_global_warming/'
-    exp_name='bog_fixed_sst_control_experiment'
+    base_exp_name='laura_no_ice_fixed_sst_perp_djf/'
+    exp_name='no_ice_precip_targets_exps_t42_finished'
     #ice_file_name=base_dir+'annual_mean_ice_albedo_change_test_mk2_4320_dt_rad_4/'+'run360/'+'atmos_monthly.nc'
     ice_file_name=None
-    output_file_name='qflux_'+exp_name
+    output_file_name='qflux_laura_hadg'
 
     start_file=240
     end_file=360
@@ -279,9 +279,9 @@ if __name__ == "__main__":
     avg_or_daily='monthly'
 
     #Set the time frequency of output data. Valid options are 'months', 'all_time' or 'dayofyear'.
-    time_divisions_of_qflux_to_be_calculated='months'
+    time_divisions_of_qflux_to_be_calculated='all_time'
 
-    model_params = sagp.model_params_set(input_dir, delta_t=720., ml_depth=20.)
+    model_params = sagp.model_params_set(input_dir, delta_t=720., ml_depth=20., res=42)
 
     dataset, time_arr, size_list = io.read_data( base_dir,exp_name,start_file,end_file,avg_or_daily,topo_present)
 
@@ -289,7 +289,7 @@ if __name__ == "__main__":
     dataset['land'] = (('lat','lon'),land_array)
 
     check_surface_flux_dims(dataset)
-
+    
     qflux_calc(dataset, model_params, output_file_name, ice_file_name, groupby_name=time_divisions_of_qflux_to_be_calculated)
 
 

--- a/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
+++ b/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
@@ -264,16 +264,16 @@ if __name__ == "__main__":
     input_dir=GFDL_BASE
     base_dir=GFDL_DATA
     land_file='input/era_land_t42.nc'
-    base_exp_name='laura_no_ice_fixed_sst_perp_djf/'
-    exp_name='no_ice_precip_targets_exps_t42_finished'
+    base_exp_name='laura_no_ice_fixed_sst_perp_djf/' #Folder containing the python script and input files that ran the experiment
+    exp_name='no_ice_precip_targets_exps_t42_finished' #Folder within the data directory where the files can be found
     #ice_file_name=base_dir+'annual_mean_ice_albedo_change_test_mk2_4320_dt_rad_4/'+'run360/'+'atmos_monthly.nc'
     ice_file_name=None
-    output_file_name='qflux_laura_hadg'
+    output_file_name='qflux_laura_hadg' #Proposed name of your output qflux file
 
     start_file=240
     end_file=360
     land_present=True
-    topo_present=False
+    use_interpolated_pressure_level_data = False #Conditions the script on whether to expect data on sigma levels (if False) or pressure levels (if True). Script should be insensitive to this choice if both sets of files exist. 
 
     #Set time increments of input files (e.g. `monthly` for `atmos_monthly` files.
     avg_or_daily='monthly'
@@ -283,9 +283,9 @@ if __name__ == "__main__":
 
     model_params = sagp.model_params_set(input_dir, delta_t=720., ml_depth=20., res=42)
 
-    dataset, time_arr, size_list = io.read_data( base_dir,exp_name,start_file,end_file,avg_or_daily,topo_present)
+    dataset, time_arr, size_list = io.read_data( base_dir,exp_name,start_file,end_file,avg_or_daily,use_interpolated_pressure_level_data)
 
-    land_array, topo_array = io.read_land(input_dir,base_exp_name,land_present,topo_present,size_list,land_file)
+    land_array, topo_array = io.read_land(input_dir,base_exp_name,land_present,use_interpolated_pressure_level_data,size_list,land_file)
     dataset['land'] = (('lat','lon'),land_array)
 
     check_surface_flux_dims(dataset)

--- a/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
+++ b/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
@@ -24,7 +24,7 @@ def qflux_calc(dataset, model_params, output_file_name, ice_file_name=None, grou
         deep_ocean_heat_content(dataset, model_params)
         ocean_transport(dataset, model_params)
 
-        output_dict={'manual_grid_option':False, 'is_thd':False, 'num_years':1., 'time_spacing_days':12, 'file_name':output_file_name+'.nc', 'var_name':output_file_name}
+        output_dict={'manual_grid_option':False, 'is_thd':False, 'num_years':1., 'time_spacing_days':12, 'file_name':output_file_name+'.nc', 'var_name':output_file_name} #Have specified that var name is the same as file name as this is what the fortran assumes.
         
     elif groupby_name=='dayofyear':
         time_varying_ice = ice_mask_calculation(dataset, dataset.land, ice_file_name)
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     exp_name='no_ice_precip_targets_exps_t42_finished' #Folder within the data directory where the files can be found
     #ice_file_name=base_dir+'annual_mean_ice_albedo_change_test_mk2_4320_dt_rad_4/'+'run360/'+'atmos_monthly.nc'
     ice_file_name=None
-    output_file_name='qflux_laura_hadg' #Proposed name of your output qflux file
+    output_file_name='qflux_laura_hadg' #Proposed name of your output qflux file. Will also be qflux field name in q-flux netcdf file as the fortran assumes file-name = field name. No need to add '.nc' or any file paths in this variable as otherwise they will end up in the field name too. Output file will be stored in the same directory as this script.
 
     start_file=240
     end_file=360

--- a/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
+++ b/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     exp_name='bog_fixed_sst_control_experiment'
     #ice_file_name=base_dir+'annual_mean_ice_albedo_change_test_mk2_4320_dt_rad_4/'+'run360/'+'atmos_monthly.nc'
     ice_file_name=None
-    output_file_name='qflux_bog_fixed_sst_control_experiment'
+    output_file_name='qflux_'+exp_name
 
     start_file=240
     end_file=360

--- a/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
+++ b/src/extra/python/scripts/calculate_qflux/calculate_qflux.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
         GFDL_BASE        = os.environ['GFDL_BASE']
         GFDL_WORK        = os.environ['GFDL_WORK']
         GFDL_DATA        = os.environ['GFDL_DATA']        
-    except Exception, e:
+    except Exception as e:
         print('Environment variables GFDL_BASE, GFDL_WORK, GFDL_DATA must be set')
         exit(0)
 

--- a/src/extra/python/scripts/calculate_qflux/nc_file_io_xarray.py
+++ b/src/extra/python/scripts/calculate_qflux/nc_file_io_xarray.py
@@ -10,7 +10,7 @@ from scipy import stats
 
 __author__='Stephen Thomson'
 
-def read_data( base_dir, exp_name, start_file, end_file, avg_or_daily, topo_present, model='fms13', file_name=None):
+def read_data( base_dir, exp_name, start_file, end_file, avg_or_daily, use_interpolated_pressure_level_data, model='fms13', file_name=None):
 
     if model=='fms13':
 
@@ -18,7 +18,7 @@ def read_data( base_dir, exp_name, start_file, end_file, avg_or_daily, topo_pres
                                 [base_dir+'/'+exp_name+'/run%04d' % m for m in range(start_file, end_file+1)],
                                 [base_dir+'/'+exp_name+'/run%d'   % m for m in range(start_file, end_file+1)]]
 
-        if(topo_present):
+        if(use_interpolated_pressure_level_data):
             if avg_or_daily == 'monthly':
 #                 extra='_interp.nc'
                 extra='_interp_new_height.nc'
@@ -201,7 +201,7 @@ def init( nc_file_init):
     
     return    size_list
 
-def read_land( base_dir,exp_name,land_present,topo_present,size_list,land_file='input/land.nc', lats_in = None):
+def read_land( base_dir,exp_name,land_present, use_interpolated_pressure_level_data, size_list,land_file='input/land.nc', lats_in = None):
     "Function for reading in land mask."
     
     #Create thd (3D) and twd (2D) data stores.
@@ -209,7 +209,7 @@ def read_land( base_dir,exp_name,land_present,topo_present,size_list,land_file='
     topo_array=np.zeros((size_list['nlats'],size_list['nlons']))
     
     if land_file is not None:
-        if(land_present or topo_present):
+        if(land_present or use_interpolated_pressure_level_data):
             nc_file = base_dir+'exp/'+exp_name+land_file
             print(nc_file)
             try:
@@ -232,7 +232,7 @@ def read_land( base_dir,exp_name,land_present,topo_present,size_list,land_file='
                     if lats_in[0]!=lat_land[0]:
                         land_array=land_array[::-1,:]
                     
-            if topo_present:
+            if use_interpolated_pressure_level_data:
                 topo_array=fh.variables['zsurf'][:]
             fh.close()
 

--- a/src/extra/python/scripts/calculate_qflux/nc_file_io_xarray.py
+++ b/src/extra/python/scripts/calculate_qflux/nc_file_io_xarray.py
@@ -241,8 +241,17 @@ def read_land( base_dir,exp_name,land_present,topo_present,size_list,land_file='
 def output_nc_file(dataset, field_name, model_params, output_dict):
 
     #create grid
-
-    lons,lats,lonbs,latbs,nlon,nlat,nlonb,nlatb=cts.create_grid(output_dict['manual_grid_option'])
+    try:
+        lons = dataset.lon.values
+        lats = dataset.lat.values
+        latbs = dataset.latb.values
+        lonbs = dataset.lonb.values
+        nlon = lons.shape[0]
+        nlat = lats.shape[0]
+        nlatb = latbs.shape[0]
+        nlonb = lonbs.shape[0]
+    except:
+        lons,lats,lonbs,latbs,nlon,nlat,nlonb,nlatb=cts.create_grid(output_dict['manual_grid_option'])
 
     if output_dict['is_thd']:
         p_full,p_half,npfull,nphalf=cts.create_pressures()

--- a/src/extra/python/scripts/calculate_qflux/set_and_get_params.py
+++ b/src/extra/python/scripts/calculate_qflux/set_and_get_params.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pdb
+import sys
+sys.path.append('../')
 import cell_area as carea
 
 __author__='Stephen Thomson'

--- a/src/extra/python/scripts/create_amip_sst_timeseries.py
+++ b/src/extra/python/scripts/create_amip_sst_timeseries.py
@@ -124,11 +124,15 @@ def apply_lat_lon_mask( unmasked_input, lat_range, lon_range_in, taper_length, p
 
 def main():
 
-    base_directory='/scratch/sit204/sst_amip_files/'
+    base_directory='/scratch/sit204/collab/laura_wilcox/'
+#     base_directory='/scratch/sit204/sst_amip_files/'
 
-    amip_data_version='amip_data_version_1_1_0' #s 'amip_data_version_1_1_0' or 'amip_data_version_1_0_0'
 
-    output_name_list  ={'tosbcs':'sst','siconc':'siconc'}
+    amip_data_version='hadgem_t_surf' #s 'amip_data_version_1_1_0' or 'amip_data_version_1_0_0'
+#     amip_data_version='amip_data_version_1_1_0'
+
+    output_name_list  ={'DJF':'sst'}
+#     output_name_list  ={'tosbcs':'sst'}
     #Note that we are using the bcs (boundary conditions) input4MIPs files, as instructed.
     # The theory is that by using the bcs files (which are mid-month values) the time-average
     # of the interpolated bcs files should be equal to the time-average data provided in 'tos'
@@ -137,8 +141,7 @@ def main():
 
     add_anomaly = False
 #     anomaly_type='el_nino'
-    months_to_include='all'
-    months_to_include='DJF'    
+    months_to_include='only_month_available'
 
     for variable_name in list(output_name_list.keys()):
 
@@ -153,6 +156,11 @@ def main():
             folder_name=''
             filename_prefix=variable_name+'_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-1-0_gs1x1_187001-201512'
             do_annual_mean=False
+        elif amip_data_version=='hadgem_t_surf':
+            nfiles=1
+            folder_name=''
+            filename_prefix='ts_clim'
+            do_annual_mean=False        
 
         for file_tick in range(nfiles):
 
@@ -180,28 +188,39 @@ def main():
                 sst_all=sst_in
 
         try:
+            no_latb_lonb = False
             lonbs = resolution_file.variables['bounds_longitude'][:]
             latbs = resolution_file.variables['bounds_latitude'][:]
         except KeyError:
-            lonbs = resolution_file.variables['lon_bnds'][:]
-            latbs = resolution_file.variables['lat_bnds'][:]
+            try:
+                lonbs = resolution_file.variables['lon_bnds'][:]
+                latbs = resolution_file.variables['lat_bnds'][:]
+            except:
+                no_latb_lonb=True
 
         nlon=lons.shape[0]
         nlat=lats.shape[0]
 
-        nlonb=lonbs.shape[0]
-        nlatb=latbs.shape[0]
+        if not no_latb_lonb:
+            nlonb=lonbs.shape[0]
+            nlatb=latbs.shape[0]
 
-        lonbs_adjusted=np.zeros(nlonb+1)
-        latbs_adjusted=np.zeros(nlatb+1)
+            lonbs_adjusted=np.zeros(nlonb+1)
+            latbs_adjusted=np.zeros(nlatb+1)
 
-        lonbs_adjusted[0:nlonb]=lonbs[:,0]
-        lonbs_adjusted[nlonb]=lonbs[-1,1]
+            lonbs_adjusted[0:nlonb]=lonbs[:,0]
+            lonbs_adjusted[nlonb]=lonbs[-1,1]
 
-        latbs_adjusted[0:nlatb]=latbs[:,0]
-        latbs_adjusted[nlatb]=latbs[-1,1]
+            latbs_adjusted[0:nlatb]=latbs[:,0]
+            latbs_adjusted[nlatb]=latbs[-1,1]
+        else:
+            latbs_adjusted = None
+            lonbs_adjusted = None
 
-        day_number = resolution_file.variables['time'][:]
+        try:
+            day_number = resolution_file.variables['time'][:]
+        except:
+            day_number = np.ones(12)   
 
         time_arr = day_number_to_date(day_number, calendar_type = 'gregorian', units_in = 'days since 1870-1-1')
         time_arr_adj=np.arange(15,360,30)
@@ -211,7 +230,7 @@ def main():
         if len(sst_all.shape)==4:
             sst_in=np.mean(sst_all,axis=0)
         else:
-            sst_in=np.zeros((12,180,360))
+            sst_in=np.zeros((12,nlat,nlon))
             
             if months_to_include=='all':
                 for month_tick in np.arange(1,13,1):
@@ -224,10 +243,15 @@ def main():
                 for month_tick in np.arange(1,13,1):
                     sst_in[month_tick-1,...]=djf_mean
                 annual_mean_name='_djf'
+            
+            elif months_to_include=='only_month_available':
+                for month_tick in np.arange(1,13,1):
+                    month_idx = np.where(time_arr.month==month_tick)[0]
+                    sst_in[month_tick-1,:,:]=sst_all
 
         if do_annual_mean:
             sst_in_am=np.mean(sst_in,axis=0)
-            sst_in=np.zeros((12,180,360))
+            sst_in=np.zeros((12,nlat,nlon))
             for month_tick in np.arange(1,13,1):
                 sst_in[month_tick-1,:,:]=sst_in_am
             annual_mean_name='_am'
@@ -247,23 +271,25 @@ def main():
         #Find grid and time numbers
 
         ntime=time_arr.day.shape[0]
-        nlonb=lonbs_adjusted.shape[0]
-        nlatb=latbs_adjusted.shape[0]
-
+        if not no_latb_lonb:        
+            nlonb=lonbs_adjusted.shape[0]
+            nlatb=latbs_adjusted.shape[0]
 
         #Output it to a netcdf file. 
-        variable_name=output_name_list[variable_name]+annual_mean_name+'_clim_amip'+anom_name        
+        variable_name=output_name_list[variable_name]+annual_mean_name+'_clim_'+amip_data_version[0:5]+anom_name        
         file_name=variable_name+'_'+amip_data_version+'.nc'
 
 
         number_dict={}
         number_dict['nlat']=nlat
         number_dict['nlon']=nlon
-        number_dict['nlatb']=nlatb
-        number_dict['nlonb']=nlonb
         number_dict['npfull']=npfull
         number_dict['nphalf']=nphalf
         number_dict['ntime']=ntime
+
+        if not no_latb_lonb:
+            number_dict['nlatb']=nlatb
+            number_dict['nlonb']=nlonb
 
         time_units='days since 0000-01-01 00:00:00.0'
 

--- a/src/extra/python/scripts/create_amip_sst_timeseries.py
+++ b/src/extra/python/scripts/create_amip_sst_timeseries.py
@@ -124,15 +124,12 @@ def apply_lat_lon_mask( unmasked_input, lat_range, lon_range_in, taper_length, p
 
 def main():
 
-    base_directory='/scratch/sit204/collab/laura_wilcox/'
-#     base_directory='/scratch/sit204/sst_amip_files/'
+    base_directory='/scratch/sit204/sst_amip_files/'
 
 
-    amip_data_version='hadgem_t_surf' #s 'amip_data_version_1_1_0' or 'amip_data_version_1_0_0'
-#     amip_data_version='amip_data_version_1_1_0'
+    amip_data_version='amip_data_version_1_1_0' #s 'amip_data_version_1_1_0' or 'amip_data_version_1_0_0'
 
-    output_name_list  ={'DJF':'sst'}
-#     output_name_list  ={'tosbcs':'sst'}
+    output_name_list  ={'tosbcs':'sst', 'siconc':'siconc'}
     #Note that we are using the bcs (boundary conditions) input4MIPs files, as instructed.
     # The theory is that by using the bcs files (which are mid-month values) the time-average
     # of the interpolated bcs files should be equal to the time-average data provided in 'tos'
@@ -141,7 +138,7 @@ def main():
 
     add_anomaly = False
 #     anomaly_type='el_nino'
-    months_to_include='only_month_available'
+    months_to_include='all'
 
     for variable_name in list(output_name_list.keys()):
 

--- a/src/extra/python/scripts/create_timeseries.py
+++ b/src/extra/python/scripts/create_timeseries.py
@@ -120,8 +120,17 @@ def output_to_file(data,lats,lons,latbs,lonbs,p_full,p_half,time_arr,time_units,
     lat = output_file.createDimension('lat', number_dict['nlat'])
     lon = output_file.createDimension('lon', number_dict['nlon'])
 
-    latb = output_file.createDimension('latb', number_dict['nlatb'])
-    lonb = output_file.createDimension('lonb', number_dict['nlonb'])
+    use_latbs=False
+    use_lonbs=False
+    
+    if latbs is not None:
+        latb = output_file.createDimension('latb', number_dict['nlatb'])
+        latitudebs = output_file.createVariable('latb','d',('latb',))
+        
+
+    if lonbs is not None:    
+        lonb = output_file.createDimension('lonb', number_dict['nlonb'])
+        longitudebs = output_file.createVariable('lonb','d',('lonb',))
 
     if is_thd:
         pfull = output_file.createDimension('pfull', number_dict['npfull'])
@@ -131,9 +140,7 @@ def output_to_file(data,lats,lons,latbs,lonbs,p_full,p_half,time_arr,time_units,
 
     latitudes = output_file.createVariable('lat','d',('lat',))
     longitudes = output_file.createVariable('lon','d',('lon',))
-
-    latitudebs = output_file.createVariable('latb','d',('latb',))
-    longitudebs = output_file.createVariable('lonb','d',('lonb',))
+    
     if is_thd:
         pfulls = output_file.createVariable('pfull','d',('pfull',))
         phalfs = output_file.createVariable('phalf','d',('phalf',))
@@ -142,21 +149,23 @@ def output_to_file(data,lats,lons,latbs,lonbs,p_full,p_half,time_arr,time_units,
 
     latitudes.units = 'degrees_N'.encode('utf-8')
     latitudes.cartesian_axis = 'Y'
-    latitudes.edges = 'latb'
     latitudes.long_name = 'latitude'
 
     longitudes.units = 'degrees_E'.encode('utf-8')
     longitudes.cartesian_axis = 'X'
-    longitudes.edges = 'lonb'
     longitudes.long_name = 'longitude'
 
-    latitudebs.units = 'degrees_N'.encode('utf-8')
-    latitudebs.cartesian_axis = 'Y'
-    latitudebs.long_name = 'latitude edges'
+    if use_latbs:
+        latitudes.edges = 'latb'
+        latitudebs.units = 'degrees_N'.encode('utf-8')
+        latitudebs.cartesian_axis = 'Y'
+        latitudebs.long_name = 'latitude edges'
 
-    longitudebs.units = 'degrees_E'.encode('utf-8')
-    longitudebs.cartesian_axis = 'X'
-    longitudebs.long_name = 'longitude edges'
+    if use_lonbs:
+        longitudes.edges = 'lonb'
+        longitudebs.units = 'degrees_E'.encode('utf-8')
+        longitudebs.cartesian_axis = 'X'
+        longitudebs.long_name = 'longitude edges'
 
     if is_thd:
         pfulls.units = 'hPa'
@@ -197,8 +206,10 @@ def output_to_file(data,lats,lons,latbs,lonbs,p_full,p_half,time_arr,time_units,
     latitudes[:] = lats
     longitudes[:] = lons
 
-    latitudebs[:] = latbs
-    longitudebs[:] = lonbs
+    if use_latbs:
+        latitudebs[:] = latbs
+    if use_lonbs:
+        longitudebs[:] = lonbs
 
     if is_thd:
         pfulls[:]     = p_full

--- a/src/extra/python/scripts/create_timeseries.py
+++ b/src/extra/python/scripts/create_timeseries.py
@@ -126,11 +126,12 @@ def output_to_file(data,lats,lons,latbs,lonbs,p_full,p_half,time_arr,time_units,
     if latbs is not None:
         latb = output_file.createDimension('latb', number_dict['nlatb'])
         latitudebs = output_file.createVariable('latb','d',('latb',))
-        
+        use_latbs=True
 
     if lonbs is not None:    
         lonb = output_file.createDimension('lonb', number_dict['nlonb'])
         longitudebs = output_file.createVariable('lonb','d',('lonb',))
+        use_lonbs=True
 
     if is_thd:
         pfull = output_file.createDimension('pfull', number_dict['npfull'])

--- a/src/extra/python/scripts/create_timeseries.py
+++ b/src/extra/python/scripts/create_timeseries.py
@@ -29,7 +29,7 @@ def create_grid(manual_grid_option):
 
         try:
             GFDL_BASE        = os.environ['GFDL_BASE']
-        except Exception, e:
+        except Exception as e:
             print('Environment variable GFDL_BASE must be set')
             exit(0)
 

--- a/src/extra/python/scripts/general_spinup_fn.py
+++ b/src/extra/python/scripts/general_spinup_fn.py
@@ -10,19 +10,23 @@ from cell_area import cell_area
 import pdb
 import os
 
-def q_spinup(run_fol, var_to_integrate, start_month, end_month, plt_dir):
+def q_spinup(run_fol, var_to_integrate, start_month, end_month, plt_dir, t_resolution=42, data_dir_type = 'isca', power=1.):
 
     #personalise
     #model directory
-    model_dir = '/scratch/sit204/FMS2013/GFDLmoistModel/'
+    model_dir = '/scratch/sit204/Isca/'
     #data directory
-    data_dir = '/scratch/sit204/Data_2013/'
+    if data_dir_type=='isca':
+        data_dir = '/scratch/sit204/data_isca/'
+    elif data_dir_type == 'isca_cpu':
+        data_dir = '/scratch/sit204/data_from_isca_cpu/'
+    else:
+        data_dir = '/scratch/sit204/Data_2013/'    
     #file name
     file_name='atmos_monthly.nc'
     #time-resolution of plotting
     group='months'
     scaling=1.
-    t_resolution=42
     nlon=128
     nlat=64
     gravity=9.8
@@ -31,34 +35,29 @@ def q_spinup(run_fol, var_to_integrate, start_month, end_month, plt_dir):
 
     #get cell areas and pressure thicknesses
 
-    try:
-        files_temp=[data_dir+'/'+run_fol+'/run%03d/' % m for m in range(start_month, end_month+1)]
+    possible_format_strs = [[data_dir+'/'+run_fol+'/run%03d/' % m for m in range(start_month, end_month+1)],
+                            [data_dir+'/'+run_fol+'/run%04d/' % m for m in range(start_month, end_month+1)],
+                            [data_dir+'/'+run_fol+'/run%d/' % m for m in range(start_month, end_month+1)]]
 
+    for format_str_files in possible_format_strs:
+        files_temp = format_str_files
         names = [s + file_name for s in files_temp]
-
         thd_files_exist=[os.path.isfile(s) for s in names]
-
-        print((names[0]))
-
-        if not(all(thd_files_exist)):
-            raise EOFError('EXITING BECAUSE OF MISSING FILES', [names[elem] for elem in range(len(thd_files_exist)) if not thd_files_exist[elem]])
         
-        rundata = xr.open_dataset(names[0],
-                     decode_times=False)  # no calendar so tell netcdf lib
-    except (RuntimeError, OSError):
-        files_temp=[data_dir+'/'+run_fol+'/run%d/' % m for m in range(start_month, end_month+1)]
+        if thd_files_exist[0]:
+            break
+        
+        if not thd_files_exist[0] and format_str_files==possible_format_strs[-1]:
+            raise EOFError('EXITING BECAUSE NO APPROPRIATE FORMAT STR', [names[elem] for elem in [0] if not thd_files_exist[elem]])
+    
+    print(names[0])
+    
+    if not(all(thd_files_exist)):
+        raise EOFError('EXITING BECAUSE OF MISSING FILES', [names[elem] for elem in range(len(thd_files_exist)) if not thd_files_exist[elem]])
+    
+    rundata = xr.open_dataset(names[0],
+                 decode_times=False)  # no calendar so tell netcdf lib
 
-        names = [s + file_name for s in files_temp]
-
-        thd_files_exist=[os.path.isfile(s) for s in names]
-
-        print((names[0]))
-
-        if not(all(thd_files_exist)):
-            raise EOFError('EXITING BECAUSE OF MISSING FILES', [names[elem] for elem in range(len(thd_files_exist)) if not thd_files_exist[elem]])
-
-        rundata = xr.open_dataset(names[0],
-                     decode_times=False)  # no calendar so tell netcdf lib
 
     area = cell_area(t_resolution, model_dir)
     area_xr = xr.DataArray(area, [('lat', rundata.lat ), ('lon', rundata.lon)])
@@ -76,7 +75,7 @@ def q_spinup(run_fol, var_to_integrate, start_month, end_month, plt_dir):
     rundata.coords['months'] = time_arr // 30 + 1
     rundata.coords['years'] = ((time_arr // 360) +1)*scaling - 6.
 
-    q_yr = (rundata[var_to_integrate]).groupby(group).mean(('time'))
+    q_yr = (rundata[var_to_integrate]**power).groupby(group).mean(('time'))
 
     #take area mean of q
     q_av = q_yr*area_xr
@@ -111,25 +110,30 @@ def q_spinup(run_fol, var_to_integrate, start_month, end_month, plt_dir):
 
 if __name__ == "__main__":
 
-    start_month_offset=[0, 0]
-
-    exp_list=['no_ice_flux_lhe_exps_fixed_sst_1', 'no_ice_flux_q_exps_qflux_control_1']
+    start_month_offset=[0,0, 0, 0, 0, 0, 0]
     
-    label_arr=['fixed DJF sst no ice', 'q-flux control DJF no ice']
-           
+    exp_list = ['bog_fixed_sst_control_experiment_outside', 'bog_qflux_control_experiment_outside', 'annual_mean_ice_post_princeton_fixed_sst_1', 'bog_qflux_control_experiment_outside_1', 'bog_fixed_sst_control_experiment_outside_isca_bog_a', 'bog_qflux_control_experiment_outside_10', 'bog_qflux_control_experiment_outside_8']
+
+    label_arr = ['fixed sst bog', 'qflux bog', 'fixed sst rrtm', 'qflux isca bog_a', 'fixed sst isca bog_a', 'qflux isca 0.1', 'qflux isca 0.08']
+
+    res_arr = [42, 42, 42, 42, 42, 42, 42]
+
+    data_type_arr = ['isca_cpu', 'isca_cpu', '2013', 'isca', 'isca_cpu', 'isca', 'isca']
+
     exp_name=exp_list
 
     #number of years to read
-    start_month_arr=[1, 1]
-    end_month_arr=[360, 292]
+    start_month_arr=[1, 1, 1, 1, 1, 1, 1]
+    end_month_arr=[360, 76, 360, 359, 360, 359, 359]
 
-    len_list=[len(start_month_offset), len(exp_list), len(label_arr), len(start_month_arr), len(end_month_arr)]
+    len_list=[len(start_month_offset), len(exp_list), len(label_arr), len(start_month_arr), len(end_month_arr), len(res_arr), len(data_type_arr)]
 
     if not all(x==len_list[0] for x in len_list):
         raise IndexError("Input arrays to routine are not all the same length")
 
 
-    variable_to_integrate='temp'
+    variable_to_integrate='t_surf'
+    power_to_scale_variable_by=1.
 
     plt.figure()
 
@@ -140,14 +144,14 @@ if __name__ == "__main__":
         if not os.path.exists(plt_dir):
             os.makedirs(plt_dir)
         idx=exp_list.index(exp_number)
-        print(('running ', exp_number))
+        print('running '+ exp_number)
         #return integral of area mean q over stratosphere and whole atmosphere
-        q_strat, q_vint, time = q_spinup(run_fol, variable_to_integrate, start_month_arr[idx]+start_month_offset[idx], end_month_arr[idx]+start_month_offset[idx], plt_dir)
+        q_strat, q_vint, time = q_spinup(run_fol, variable_to_integrate, start_month_arr[idx]+start_month_offset[idx], end_month_arr[idx]+start_month_offset[idx], plt_dir, res_arr[idx], data_type_arr[idx], power_to_scale_variable_by )
         plt.plot(time,q_vint,label=label_arr[idx])
 #         plt.plot(time,q_strat,label='strat '+label_arr[idx])
         
 
     plt.xlabel('time (months)')
-    plt.ylabel('Global average '+variable_to_integrate)
+    plt.ylabel('Global average '+variable_to_integrate+'**'+str(power_to_scale_variable_by))
     plt.legend(loc='upper left')
     plt.show()

--- a/src/extra/python/scripts/modified_time_script.py
+++ b/src/extra/python/scripts/modified_time_script.py
@@ -6,7 +6,7 @@ import sys
 from datetime import datetime
 
 
-def calculate_month_run_time(exp_dir_list, plot_against_wall_time=True):
+def calculate_month_run_time(exp_dir_list, plot_against_wall_time=True, file_to_use_for_timing = 'logfile.000000.out'):
     """A script that takes a list of experiment names as input, and plots the time taken to run each month in that experiment vs the wall time. """
 
     try:
@@ -21,7 +21,11 @@ def calculate_month_run_time(exp_dir_list, plot_against_wall_time=True):
         exp_dir_full = GFDL_DATA+'/'+exp_dir+'/'
 
         #Finds all the months for particular experiment
-        months_to_check=os.listdir(exp_dir_full) 
+        months_to_check=os.listdir(exp_dir_full)
+        try:
+            months_to_check.remove('restarts')
+        except:
+            pass 
         months_to_check.sort()
         
         try:
@@ -35,7 +39,7 @@ def calculate_month_run_time(exp_dir_list, plot_against_wall_time=True):
 
         for month in np.arange(len(months_to_check)-1)+1:
             #Calculates the time between the current month's folder being modified, and the previous month's folder being modified.
-            delta_t = os.path.getctime(exp_dir_full+months_to_check[month]+'/logfile.000000.out')-os.path.getctime(exp_dir_full+months_to_check[month-1]+'/logfile.000000.out')
+            delta_t = os.path.getctime(exp_dir_full+months_to_check[month]+'/'+file_to_use_for_timing)-os.path.getctime(exp_dir_full+months_to_check[month-1]+'/'+file_to_use_for_timing)
                        
             #Converts this time to minutes from seconds:
             delta_t_arr[month-1]=delta_t/60.
@@ -62,9 +66,9 @@ def calculate_month_run_time(exp_dir_list, plot_against_wall_time=True):
 
 if __name__=="__main__":
 
-    exp_dir_list = ['no_ice_flux_lhe_exps_fixed_sst_1']
+    exp_dir_list = ['bog_fixed_sst_low_bog_a_ocean_topog_85']
 
-    calculate_month_run_time(exp_dir_list, plot_against_wall_time=False)
+    calculate_month_run_time(exp_dir_list, plot_against_wall_time=False, file_to_use_for_timing='git_hash_used.txt')
 
     plt.show()
 


### PR DESCRIPTION
A few updates to the `caluclate-qflux` routines:

* Fixed some `import` statements that weren't finding the routines in the directory above.

* Added some functionality to cope with `flux_sw` and `flux_lw` arrays that are 3D (as is the case for grey radiation). Previous functionality only allowed for 2d arrays, as are output when using RRTM. This means that qfluxes can be calculated for runs with grey radiation.

Have also added a compile script for the pressure-level interpolator `plev.x`, and have updated the README accordingly.