### PR TITLE
Fix for when running from an old commit that does not have a mppncombine_script

### DIFF
--- a/src/extra/python/isca/experiment.py
+++ b/src/extra/python/isca/experiment.py
@@ -11,7 +11,7 @@ import tarfile
 # from gfdl import create_alert
 # import getpass
 
-from isca import GFDL_WORK, GFDL_DATA, _module_directory, get_env_file, EventEmitter
+from isca import GFDL_WORK, GFDL_DATA, GFDL_BASE, _module_directory, get_env_file, EventEmitter
 from isca.diagtable import DiagTable
 from isca.loghandler import Logger, clean_log_debug
 from isca.helpers import destructive, useworkdir, mkdir
@@ -275,7 +275,11 @@ class Experiment(Logger, EventEmitter):
 
         if num_cores > 1:
             # use postprocessing tool to combine the output from several cores
-            combinetool = sh.Command(P(self.codebase.builddir, 'mppnccombine_run.sh'))
+            codebase_combine_script = P(self.codebase.builddir, 'mppnccombine_run.sh')
+            if not os.path.exists(codebase_combine_script):
+                self.log.warning('combine script does not exist in the commit you are running Isca from.  Falling back to using $GFDL_BASE mppnccombine_run.sh script')
+                sh.ln('-s',  P(GFDL_BASE, 'postprocessing', 'mppnccombine_run.sh'), codebase_combine_script)
+            combinetool = sh.Command(codebase_combine_script)
             for file in self.diag_table.files:
                 netcdf_file = '%s.nc' % file
                 filebase = P(self.rundir, netcdf_file)


### PR DESCRIPTION
- Experiment.run now checks if the mpppncombine_run.sh script exists
  in the checked out code.  If it doesn't, use the GFDL_BASE version