### PR TITLE
Only grey sigma fix

### DIFF
--- a/src/atmos_param/two_stream_gray_rad/two_stream_gray_rad.F90
+++ b/src/atmos_param/two_stream_gray_rad/two_stream_gray_rad.F90
@@ -525,12 +525,12 @@ case(B_GEEN)
   do k = 1, n
     lw_del_tau    = ( ir_tau_co2 + 0.2023 * log(carbon_conc/360.)                  &
                     + ir_tau_wv1*log(ir_tau_wv2*q(:,:,k) + 1) )                    &
-               * ( p_half(:,:,k+1)-p_half(:,:,k) ) / p_half(:,:,n+1)
+               * ( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks
     lw_dtrans(:,:,k) = exp( - lw_del_tau )
     lw_del_tau_win   = ( ir_tau_co2_win + 0.0954 * log(carbon_conc/360.)           &
                                      + ir_tau_wv_win1*q(:,:,k)                 &
                                      + ir_tau_wv_win2*q(:,:,k)*q(:,:,k) )      &
-                  * ( p_half(:,:,k+1)-p_half(:,:,k) ) / p_half(:,:,n+1)
+                  * ( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks
     lw_dtrans_win(:,:,k) = exp( - lw_del_tau_win )
   end do
 
@@ -555,7 +555,7 @@ case(B_BYRNE)
   !      J. Climate 26, 4000–4106 (2013).
 
   do k = 1, n
-    lw_del_tau    = (bog_a*bog_mu + 0.17 * log(carbon_conc/360.)  + bog_b*q(:,:,k)) * (( p_half(:,:,k+1)-p_half(:,:,k) ) / p_half(:,:,n+1))
+    lw_del_tau    = (bog_a*bog_mu + 0.17 * log(carbon_conc/360.)  + bog_b*q(:,:,k)) * (( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks)
     lw_dtrans(:,:,k) = exp( - lw_del_tau )
 
   end do

--- a/src/atmos_param/two_stream_gray_rad/two_stream_gray_rad.F90
+++ b/src/atmos_param/two_stream_gray_rad/two_stream_gray_rad.F90
@@ -28,7 +28,7 @@ module two_stream_gray_rad_mod
                                     mpp_pe, close_file, error_mesg, &
                                     NOTE, FATAL,  uppercase
 
-   use constants_mod,         only: stefan, cp_air, grav, pstd_mks, seconds_per_sol, orbital_period
+   use constants_mod,         only: stefan, cp_air, grav, pstd_mks, pstd_mks_earth, seconds_per_sol, orbital_period
 
    use    diag_manager_mod,   only: register_diag_field, send_data
 
@@ -234,6 +234,10 @@ if(lw_scheme == B_SCHNEIDER_LIU) then
 	gp_albedo     = ( sqrt(1. - g_asym*single_albedo) - sqrt(1. - single_albedo) )        &
            / ( sqrt(1. - g_asym*single_albedo) + sqrt(1. - single_albedo) );
 	Ga_asym         = 2.*sqrt( (1. - single_albedo) * (1. - g_asym*single_albedo) );
+endif
+
+if ((lw_scheme == B_BYRNE).or.(lw_scheme == B_GEEN)) then
+    if (pstd_mks/=pstd_mks_earth) call error_mesg('two_stream_gray_rad','Pstd_mks and pstd_mks_earth are not the same in the this run, but lw scheme will use pstd_mks_earth because abs coeffs in Byrne and Geen schemes are non-dimensionalized by Earth surface pressure.', NOTE)  
 endif
 
 
@@ -525,12 +529,12 @@ case(B_GEEN)
   do k = 1, n
     lw_del_tau    = ( ir_tau_co2 + 0.2023 * log(carbon_conc/360.)                  &
                     + ir_tau_wv1*log(ir_tau_wv2*q(:,:,k) + 1) )                    &
-               * ( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks
+               * ( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks_earth
     lw_dtrans(:,:,k) = exp( - lw_del_tau )
     lw_del_tau_win   = ( ir_tau_co2_win + 0.0954 * log(carbon_conc/360.)           &
                                      + ir_tau_wv_win1*q(:,:,k)                 &
                                      + ir_tau_wv_win2*q(:,:,k)*q(:,:,k) )      &
-                  * ( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks
+                  * ( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks_earth
     lw_dtrans_win(:,:,k) = exp( - lw_del_tau_win )
   end do
 
@@ -555,7 +559,7 @@ case(B_BYRNE)
   !      J. Climate 26, 4000–4106 (2013).
 
   do k = 1, n
-    lw_del_tau    = (bog_a*bog_mu + 0.17 * log(carbon_conc/360.)  + bog_b*q(:,:,k)) * (( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks)
+    lw_del_tau    = (bog_a*bog_mu + 0.17 * log(carbon_conc/360.)  + bog_b*q(:,:,k)) * (( p_half(:,:,k+1)-p_half(:,:,k) ) / pstd_mks_earth)
     lw_dtrans(:,:,k) = exp( - lw_del_tau )
 
   end do

--- a/src/shared/constants/constants.F90
+++ b/src/shared/constants/constants.F90
@@ -243,6 +243,7 @@ real, public, parameter :: EPSLN   = 1.0e-40
 
 real, public, parameter :: EARTH_OMEGA = 7.2921150e-5
 real, public, parameter :: EARTH_ORBITAL_PERIOD = 365.25*SECONDS_PER_DAY
+real, public, parameter :: PSTD_MKS_EARTH = 101325.0
 
 real, public :: RADIUS = 6376.0e3
 real, public :: GRAV   = EARTH_GRAV
@@ -253,7 +254,7 @@ real, public :: orbital_rate  ! this is calculated from 2pi/orbital_period
 real, public :: solar_const = 1368.22             ! solar constant [ W/m2 ]
 real, public :: orbit_radius=1.0                  ! distance Earth-Sun [ AU ]
 real, public :: PSTD   = 1.013250E+06
-real, public :: PSTD_MKS    = 101325.0
+real, public :: PSTD_MKS    = PSTD_MKS_EARTH
 real, public :: RDGAS  = EARTH_RDGAS
 real, public :: KAPPA = EARTH_KAPPA
 real, public :: CP_AIR = EARTH_CP_AIR


### PR DESCRIPTION
PR #1 was put in to fix a normalisation problem for lw optical depths in BOG and Geen grey radiation schemes. But I also added some changes to the way surface pressure was defined, which proved more controversial, so it wasn't merged. This PR is just the normalisation, so should be straight forward to approve.