### PR TITLE
External namelist test

### DIFF
--- a/exp/test_cases/realistic_continents/namelist_basefile.nml
+++ b/exp/test_cases/realistic_continents/namelist_basefile.nml
@@ -1,5 +1,6 @@
-! For sets of experiments which will use predominantly the same parameters, it may be tidier to read these from an external namelist file. This example illustrates how to do this for two experiments configured with realistic continents, one using fixed SSTs, one using Q-fluxes.
-
+! For parameters which are frequently set, in order to keep python scripts tidy and clear, it may be useful to read these from an external namelist file.
+! This example illustrates how to do this for two experiments configured with realistic continents, where the only differences are the choice of surface condition, with one using fixed SSTs and the other Q-fluxes.
+! If you find you have a 'default' set of parameter choices, this method may be useful to ensure these are set consistently for all of your experiments. ! NB Note that this example is for a specific case, and would likely need modifying for your specific set-up.
 
  &main_nml
     days   = 30,
@@ -7,7 +8,7 @@
     minutes = 0,
     seconds = 0,
     dt_atmos = 720,
-    current_date = [0001,1,1,0,0,0],
+    current_date = 0001 1 1 0 0 0,
     calendar = 'thirty_day'/
 
  &idealized_moist_phys_nml
@@ -49,7 +50,7 @@
  &mixed_layer_nml
     tconst      = 285.,
     prescribe_initial_dist = .true.,
-    evaporation = .true.
+    evaporation = .true.,
     delta_T = 0.,                       !Set latitude contrast in initial temperature profile to zero
     depth = 20.,                        !Mixed layer depth
     land_option = 'input',              !Tell mixed layer to get land mask from input file
@@ -58,7 +59,7 @@
     land_albedo_prefactor = 1.3,        !What factor to multiply ocean albedo by over land    
     update_albedo_from_ice = .true.,    !Use the simple ice model to update surface albedo
     ice_albedo_value = 0.7,             !What value of albedo to use in regions of ice
-    ice_concentration_threshold' = 0.5/ !ice concentration threshold above which to make albedo equal to ice_albedo_value        
+    ice_concentration_threshold = 0.5/ !ice concentration threshold above which to make albedo equal to ice_albedo_value        
 
  &betts_miller_nml
        rhbm   = .7   , 
@@ -81,7 +82,7 @@
  &rrtm_radiation_nml
      do_read_ozone   = .true.,
      ozone_file      = 'ozone_1990',
-     solr_cnst       = 1360.
+     solr_cnst       = 1360.,
 	 dt_rad          = 4320/
 
 

--- a/exp/test_cases/realistic_continents/namelist_basefile.nml
+++ b/exp/test_cases/realistic_continents/namelist_basefile.nml
@@ -1,0 +1,119 @@
+! For sets of experiments which will use predominantly the same parameters, it may be tidier to read these from an external namelist file. This example illustrates how to do this for two experiments configured with realistic continents, one using fixed SSTs, one using Q-fluxes.
+
+
+ &main_nml
+    days   = 30,
+    hours  = 0,
+    minutes = 0,
+    seconds = 0,
+    dt_atmos = 720,
+    current_date = [0001,1,1,0,0,0],
+    calendar = 'thirty_day'/
+
+ &idealized_moist_phys_nml
+    do_damping      = .true.,
+    turb            = .true.,
+    mixed_layer_bc  = .true.,
+    do_virtual      = .false.,
+    do_simple       = .true.,
+    two_stream_gray = .false.,                  !Don't use grey radiation
+    do_rrtm_radiation = .true.,                 !Do use RRTM radiation
+    convection_scheme = 'FULL_BETTS_MILLER',    !Use the full betts-miller convection scheme
+    land_option = 'input',                      !Use land mask from input file
+    land_file_name = 'INPUT/era_land_t42.nc',   !Tell model where to find input file
+    land_roughness_prefactor = 10.0,            !How much rougher to make land than ocean
+    roughness_mom   = 2.e-04,                   !Ocean roughness lengths  
+    roughness_heat  = 2.e-04,                   !Ocean roughness lengths  
+    roughness_moist = 2.e-04 /                  !Ocean roughness lengths  
+
+ &vert_turb_driver_nml
+   do_mellor_yamada       = .false.,  ! default: True
+   do_diffusivity         = .true.,   ! default: False
+   do_simple              = .true.,   ! default: False
+   constant_gust          = 0.0,      ! default: 1.0
+   use_tau                = .false./        
+
+ &diffusivity_nml
+    do_entrain         = .false.,
+    do_simple          = .true./
+
+ &surface_flux_nml
+    use_virtual_temp = .false.,
+    do_simple  = .true.,
+    old_dtaudv = .true.,
+	land_humidity_prefactor = 0.7 /
+
+ &atmosphere_nml
+    idealized_moist_model = .true. /
+
+ &mixed_layer_nml
+    tconst      = 285.,
+    prescribe_initial_dist = .true.,
+    evaporation = .true.
+    delta_T = 0.,                       !Set latitude contrast in initial temperature profile to zero
+    depth = 20.,                        !Mixed layer depth
+    land_option = 'input',              !Tell mixed layer to get land mask from input file
+    land_h_capacity_prefactor = 0.1,    !What factor to multiply mixed-layer depth by over land. 
+    albedo_value = 0.25,                !Ocean albedo value
+    land_albedo_prefactor = 1.3,        !What factor to multiply ocean albedo by over land    
+    update_albedo_from_ice = .true.,    !Use the simple ice model to update surface albedo
+    ice_albedo_value = 0.7,             !What value of albedo to use in regions of ice
+    ice_concentration_threshold' = 0.5/ !ice concentration threshold above which to make albedo equal to ice_albedo_value        
+
+ &betts_miller_nml
+       rhbm   = .7   , 
+       do_simp = .false., 
+       do_shallower = .true./
+
+ &lscale_cond_nml
+    do_simple=.true.,
+    do_evap = .true./
+
+ &sat_vapor_pres_nml
+    do_simple = .true. /
+
+ &damping_driver_nml
+     do_rayleigh   = .true.,
+     trayfric      = -0.5,
+     sponge_pbottom=  150.,
+     do_conserve_energy = .true./
+
+ &rrtm_radiation_nml
+     do_read_ozone   = .true.,
+     ozone_file      = 'ozone_1990',
+     solr_cnst       = 1360.
+	 dt_rad          = 4320/
+
+
+! FMS Framework configuration
+      
+ &diag_manager_nml
+   mix_snapshot_average_fields = .false. /  ! time avg fields are labelled with time in middle of window
+
+ &fms_nml
+   domains_stack_size = 600000 /
+
+ &fms_io_nml
+   threading_write = 'single',
+   fileset_write = 'single' /
+
+ &spectral_dynamics_nml
+    damping_order           = 4,
+    water_correction_limit  = 200.e2,
+    robert_coeff            = 0.03,
+    reference_sea_level_press=1.e5,
+    num_levels              = 40,
+    valid_range_t 	        = 100. 800.,
+    initial_sphum           = 2.e-6,
+    vert_coord_option       = 'uneven_sigma',
+    surf_res                = 0.2,
+    scale_heights           = 11.0,
+    exponent                = 7.0, 
+	ocean_topog_smoothing   = 0.8 / !Use model's in-built spatial smoothing to smooth topography in order to prevent unwanted aliasing at low horizontal resolution    
+
+
+ &spectral_init_cond_nml
+    topog_file_name = 'era_land_t42.nc', !Name of land input file, which will also contain topography if generated using Isca's `land_file_generator_fn.py' routine.
+    topography_option = 'input'/ !Tell model to get topography from input file
+    
+    

--- a/exp/test_cases/realistic_continents/namelist_basefile.nml
+++ b/exp/test_cases/realistic_continents/namelist_basefile.nml
@@ -85,7 +85,6 @@
      solr_cnst       = 1360.,
 	 dt_rad          = 4320/
 
-
 ! FMS Framework configuration
       
  &diag_manager_nml
@@ -112,9 +111,6 @@
     exponent                = 7.0, 
 	ocean_topog_smoothing   = 0.8 / !Use model's in-built spatial smoothing to smooth topography in order to prevent unwanted aliasing at low horizontal resolution    
 
-
  &spectral_init_cond_nml
     topog_file_name = 'era_land_t42.nc', !Name of land input file, which will also contain topography if generated using Isca's `land_file_generator_fn.py' routine.
     topography_option = 'input'/ !Tell model to get topography from input file
-    
-    

--- a/exp/test_cases/realistic_continents/realistic_continents_fixed_sst_test_case.py
+++ b/exp/test_cases/realistic_continents/realistic_continents_fixed_sst_test_case.py
@@ -6,7 +6,7 @@ import f90nml
 
 from isca import IscaCodeBase, DiagTable, Experiment, Namelist, GFDL_BASE
 
-NCORES = 16
+NCORES = 4
 base_dir = os.path.dirname(os.path.realpath(__file__))
 # a CodeBase can be a directory on the computer,
 # useful for iterative development
@@ -72,5 +72,5 @@ exp.update_namelist({
 #Lets do a run!
 if __name__=="__main__":
     exp.run(1, use_restart=False, num_cores=NCORES)
-    #for i in range(2,121):
-    #    exp.run(i, num_cores=NCORES)
+    for i in range(2,121):
+        exp.run(i, num_cores=NCORES)

--- a/exp/test_cases/realistic_continents/realistic_continents_fixed_sst_test_case.py
+++ b/exp/test_cases/realistic_continents/realistic_continents_fixed_sst_test_case.py
@@ -6,7 +6,7 @@ import f90nml
 
 from isca import IscaCodeBase, DiagTable, Experiment, Namelist, GFDL_BASE
 
-NCORES = 4
+NCORES = 16
 base_dir = os.path.dirname(os.path.realpath(__file__))
 # a CodeBase can be a directory on the computer,
 # useful for iterative development
@@ -55,7 +55,7 @@ exp.diag_table = diag
 exp.clear_rundir()
 
 #Define values for the 'core' namelist
-namelist_name = os.path.join(GFDL_BASE, 'exp/test_cases/namelist_basefile.nml')
+namelist_name = os.path.join(GFDL_BASE, 'exp/test_cases/realistic_continents/namelist_basefile.nml')
 nml = f90nml.read(namelist_name)
 exp.namelist = nml
 
@@ -72,5 +72,5 @@ exp.update_namelist({
 #Lets do a run!
 if __name__=="__main__":
     exp.run(1, use_restart=False, num_cores=NCORES)
-    for i in range(2,121):
-        exp.run(i, num_cores=NCORES)
+    #for i in range(2,121):
+    #    exp.run(i, num_cores=NCORES)

--- a/exp/test_cases/realistic_continents/realistic_continents_fixed_sst_test_case.py
+++ b/exp/test_cases/realistic_continents/realistic_continents_fixed_sst_test_case.py
@@ -2,6 +2,8 @@ import os
 
 import numpy as np
 
+import f90nml
+
 from isca import IscaCodeBase, DiagTable, Experiment, Namelist, GFDL_BASE
 
 NCORES = 4
@@ -53,149 +55,18 @@ exp.diag_table = diag
 exp.clear_rundir()
 
 #Define values for the 'core' namelist
-exp.namelist = namelist = Namelist({
-    'main_nml': {
-        'days'   : 30,
-        'hours'  : 0,
-        'minutes': 0,
-        'seconds': 0,
-        'dt_atmos':720,
-        'current_date' : [0001,1,1,0,0,0],
-        'calendar' : 'thirty_day'
-    },
+namelist_name = os.path.join(GFDL_BASE, 'exp/test_cases/namelist_basefile.nml')
+nml = f90nml.read(namelist_name)
+exp.namelist = nml
 
-    'idealized_moist_phys_nml': {
-        'do_damping': True,
-        'turb':True,
-        'mixed_layer_bc':True,
-        'do_virtual' :False,
-        'do_simple': True,
-        'two_stream_gray':False, #Don't use grey radiation
-        'do_rrtm_radiation':True, #Do use RRTM radiation
-        'convection_scheme': 'FULL_BETTS_MILLER', #Use the full betts-miller convection scheme
-        'land_option': 'input', #Use land mask from input file
-        'land_file_name': 'INPUT/era_land_t42.nc', #Tell model where to find input file
-        'land_roughness_prefactor' : 10.0, #How much rougher to make land than ocean
-        'roughness_mom' : 2.e-4, #Ocean roughness lengths
-        'roughness_heat' : 2.e-4, #Ocean roughness lengths
-        'roughness_moist' : 2.e-4, #Ocean roughness lengths        
-    },
-
-    'vert_turb_driver_nml': {
-        'do_mellor_yamada': False,     # default: True
-        'do_diffusivity': True,        # default: False
-        'do_simple': True,             # default: False
-        'constant_gust': 0.0,          # default: 1.0
-        'use_tau': False
-    },
-    
-    'diffusivity_nml': {
-        'do_entrain':False,
-        'do_simple': True,
-    },
-
-    'surface_flux_nml': {
-        'use_virtual_temp': False,
-        'do_simple': True,
-        'old_dtaudv': True,
-        'land_humidity_prefactor': 0.7 #Evaporative resistance over land
-    },
-
-    'atmosphere_nml': {
-        'idealized_moist_model': True
-    },
-
-    #Use a large mixed-layer depth, and the Albedo of the CTRL case in Jucker & Gerber, 2017
-    'mixed_layer_nml': {
-        'tconst' : 285.,
-        'prescribe_initial_dist':True,
-        'evaporation':True,    
-        'delta_T' : 0., #Set latitude contrast in initial temperature profile to zero
-        'depth' : 20., #Mixed layer depth
-        'land_option' : 'input', #Tell mixed layer to get land mask from input file
-        'land_h_capacity_prefactor': 0.1, #What factor to multiply mixed-layer depth by over land. 
-        'albedo_value' : 0.25, #Ocean albedo value
-        'land_albedo_prefactor': 1.3, #What factor to multiply ocean albedo by over land    
+exp.update_namelist({
+    'mixed_layer_nml': {  
         'do_qflux' : False, #Don't use the prescribed analytical formula for q-fluxes
         'do_read_sst' : True, #Read in sst values from input file
         'do_sc_sst' : True, #Do specified ssts (need both to be true)
         'sst_file' : 'sst_clim_amip', #Set name of sst input file
         'specify_sst_over_ocean_only' : True, #Make sure sst only specified in regions of ocean.
-        'update_albedo_from_ice' : True, #Use the simple ice model to update surface albedo
-        'ice_albedo_value' : 0.7, #What value of albedo to use in regions of ice
-        'ice_concentration_threshold' : 0.5, #ice concentration threshold above which to make albedo equal to ice_albedo_value        
-                
-    },
-
-    'qe_moist_convection_nml': {
-        'rhbm':0.7,
-        'Tmin':160.,
-        'Tmax':350.   
-    },
-    
-    'lscale_cond_nml': {
-        'do_simple':True,
-        'do_evap':True
-    },
-    
-    'sat_vapor_pres_nml': {
-        'do_simple':True
-    },
-    
-    'damping_driver_nml': {
-        'do_rayleigh': True,
-        'trayfric': -0.5,              # neg. value: time in *days*
-        'sponge_pbottom':  150., #Setting the lower pressure boundary for the model sponge layer in Pa.
-        'do_conserve_energy': True,         
-    },
-
-    'rrtm_radiation_nml': {
-        'do_read_ozone':True,
-        'ozone_file':'ozone_1990',
-        'solr_cnst': 1360., #s set solar constant to 1360, rather than default of 1368.22
-        'dt_rad': 4320, # Use 4320 as RRTM timestep        
-    },
-
-    # FMS Framework configuration
-    'diag_manager_nml': {
-        'mix_snapshot_average_fields': False  # time avg fields are labelled with time in middle of window
-    },
-
-    'fms_nml': {
-        'domains_stack_size': 600000                        # default: 0
-    },
-
-    'fms_io_nml': {
-        'threading_write': 'single',                         # default: multi
-        'fileset_write': 'single',                           # default: multi
-    },
-
-    'spectral_dynamics_nml': {
-        'damping_order': 4,             
-        'water_correction_limit': 200.e2,
-        'reference_sea_level_press':1.0e5,
-        'num_levels':40,
-        'valid_range_t':[100.,800.],
-        'initial_sphum':[2.e-6],
-        'vert_coord_option':'uneven_sigma',
-        'surf_res':0.2, #Parameter that sets the vertical distribution of sigma levels
-        'scale_heights' : 11.0,
-        'exponent':7.0,
-        'robert_coeff':0.03,
-        'ocean_topog_smoothing': 0.8 #Use model's in-built spatial smoothing to smooth topography in order to prevent unwanted aliasing at low horizontal resolution        
-    },
-
-    'spectral_init_cond_nml': {
-        'topog_file_name': 'era_land_t42.nc', #Name of land input file, which will also contain topography if generated using Isca's `land_file_generator_fn.py' routine.
-        'topography_option':'input' #Tell model to get topography from input file
-        },
-    
-    'betts_miller_nml': {
-        'rhbm': 0.7,
-        'do_simp' : False,
-        'do_shallower' : True
-        }
-
+    }
 })
 
 #Lets do a run!

--- a/exp/test_cases/realistic_continents/realistic_continents_variable_qflux_test_case.py
+++ b/exp/test_cases/realistic_continents/realistic_continents_variable_qflux_test_case.py
@@ -2,6 +2,8 @@ import os
 
 import numpy as np
 
+import f90nml
+
 from isca import IscaCodeBase, DiagTable, Experiment, Namelist, GFDL_BASE
 
 NCORES = 4
@@ -25,6 +27,7 @@ cb.compile()  # compile the source code to working directory $GFDL_WORK/codebase
 # and output diagnostics
 exp = Experiment('realistic_continents_qflux_test_experiment', codebase=cb)
 
+#Add any input files that are necessary for a particular experiment.
 exp.inputfiles = [os.path.join(GFDL_BASE,'input/land_masks/era_land_t42.nc'),os.path.join(GFDL_BASE,'input/rrtm_input_files/ozone_1990.nc'),
                       os.path.join(base_dir,'input/ami_qflux_ctrl_ice_4320.nc'), os.path.join(base_dir,'input/siconc_clim_amip.nc')]
 
@@ -52,150 +55,19 @@ exp.diag_table = diag
 exp.clear_rundir()
 
 #Define values for the 'core' namelist
-exp.namelist = namelist = Namelist({
-    'main_nml': {
-        'days'   : 30,
-        'hours'  : 0,
-        'minutes': 0,
-        'seconds': 0,
-        'dt_atmos':720,
-        'current_date' : [0001,1,1,0,0,0],
-        'calendar' : 'thirty_day'
-    },
+namelist_name = os.path.join(GFDL_BASE, 'exp/test_cases/namelist_basefile.nml')
+nml = f90nml.read(namelist_name)
+exp.namelist = nml
 
-    'idealized_moist_phys_nml': {
-        'do_damping': True,
-        'turb':True,
-        'mixed_layer_bc':True,
-        'do_virtual' :False,
-        'do_simple': True,
-        'two_stream_gray':False, #Don't use grey radiation
-        'do_rrtm_radiation':True, #Do use RRTM radiation
-        'convection_scheme': 'FULL_BETTS_MILLER', #Use the full betts-miller convection scheme
-        'land_option': 'input', #Use land mask from input file
-        'land_file_name': 'INPUT/era_land_t42.nc', #Tell model where to find input file
-        'land_roughness_prefactor' : 10.0, #How much rougher to make land than ocean
-        'roughness_mom' : 2.e-4, #Ocean roughness lengths
-        'roughness_heat' : 2.e-4, #Ocean roughness lengths
-        'roughness_moist' : 2.e-4, #Ocean roughness lengths        
-    },
-
-    'vert_turb_driver_nml': {
-        'do_mellor_yamada': False,     # default: True
-        'do_diffusivity': True,        # default: False
-        'do_simple': True,             # default: False
-        'constant_gust': 0.0,          # default: 1.0
-        'use_tau': False
-    },
-    
-    'diffusivity_nml': {
-        'do_entrain':False,
-        'do_simple': True,
-    },
-
-    'surface_flux_nml': {
-        'use_virtual_temp': False,
-        'do_simple': True,
-        'old_dtaudv': True,
-        'land_humidity_prefactor': 0.7 #Evaporative resistance over land
-    },
-
-    'atmosphere_nml': {
-        'idealized_moist_model': True
-    },
-
-    #Use a large mixed-layer depth, and the Albedo of the CTRL case in Jucker & Gerber, 2017
+exp.update_namelist({
     'mixed_layer_nml': {
-        'tconst' : 285.,
-        'prescribe_initial_dist':True,
-        'evaporation':True,    
-        'delta_T' : 0., #Set latitude contrast in initial temperature profile to zero
-        'depth' : 20., #Mixed layer depth
-        'land_option' : 'input', #Tell mixed layer to get land mask from input file
-        'land_h_capacity_prefactor': 0.1, #What factor to multiply mixed-layer depth by over land. 
-        'albedo_value' : 0.25, #Ocean albedo value
-        'land_albedo_prefactor': 1.3, #What factor to multiply ocean albedo by over land    
         'do_qflux' : False, #Don't use analytic formula for q-fluxes 
         'load_qflux' : True, #Do load q-flux field from an input file
         'time_varying_qflux' : True, #q-flux will be time-varying
         'qflux_file_name' : 'ami_qflux_ctrl_ice_4320', #Name of q-flux input file
-        'update_albedo_from_ice' : True, #Use the simple ice model to update surface albedo
-        'ice_albedo_value' : 0.7, #What value of albedo to use in regions of ice
-        'ice_concentration_threshold' : 0.5, #ice concentration threshold above which to make albedo equal to ice_albedo_value        
-                
-    },
-
-    'qe_moist_convection_nml': {
-        'rhbm':0.7,
-        'Tmin':160.,
-        'Tmax':350.   
-    },
-    
-    'lscale_cond_nml': {
-        'do_simple':True,
-        'do_evap':True
-    },
-    
-    'sat_vapor_pres_nml': {
-        'do_simple':True
-    },
-    
-    'damping_driver_nml': {
-        'do_rayleigh': True,
-        'trayfric': -0.5,              # neg. value: time in *days*
-        'sponge_pbottom':  150., #Setting the lower pressure boundary for the model sponge layer in Pa.
-        'do_conserve_energy': True,         
-    },
-
-    'rrtm_radiation_nml': {
-        'do_read_ozone':True,
-        'ozone_file':'ozone_1990',
-        'solr_cnst': 1360., #s set solar constant to 1360, rather than default of 1368.22
-        'dt_rad': 4320, # Use 4320 as RRTM timestep        
-    },
-
-    # FMS Framework configuration
-    'diag_manager_nml': {
-        'mix_snapshot_average_fields': False  # time avg fields are labelled with time in middle of window
-    },
-
-    'fms_nml': {
-        'domains_stack_size': 600000                        # default: 0
-    },
-
-    'fms_io_nml': {
-        'threading_write': 'single',                         # default: multi
-        'fileset_write': 'single',                           # default: multi
-    },
-
-    'spectral_dynamics_nml': {
-        'damping_order': 4,             
-        'water_correction_limit': 200.e2,
-        'reference_sea_level_press':1.0e5,
-        'num_levels':40,
-        'valid_range_t':[100.,800.],
-        'initial_sphum':[2.e-6],
-        'vert_coord_option':'uneven_sigma',
-        'surf_res':0.2, #Parameter that sets the vertical distribution of sigma levels
-        'scale_heights' : 11.0,
-        'exponent':7.0,
-        'robert_coeff':0.03,
-        'ocean_topog_smoothing': 0.8 #Use model's in-built spatial smoothing to smooth topography in order to prevent unwanted aliasing at low horizontal resolution        
-    },
-
-    'spectral_init_cond_nml': {
-        'topog_file_name': 'era_land_t42.nc', #Name of land input file, which will also contain topography if generated using Isca's `land_file_generator_fn.py' routine.
-        'topography_option':'input' #Tell model to get topography from input file
-        },
-    
-    'betts_miller_nml': {
-        'rhbm': 0.7,
-        'do_simp' : False,
-        'do_shallower' : True
-        }
-
-
+    }
 })
+
 
 #Lets do a run!
 if __name__=="__main__":

--- a/exp/test_cases/realistic_continents/realistic_continents_variable_qflux_test_case.py
+++ b/exp/test_cases/realistic_continents/realistic_continents_variable_qflux_test_case.py
@@ -55,7 +55,7 @@ exp.diag_table = diag
 exp.clear_rundir()
 
 #Define values for the 'core' namelist
-namelist_name = os.path.join(GFDL_BASE, 'exp/test_cases/namelist_basefile.nml')
+namelist_name = os.path.join(GFDL_BASE, 'exp/test_cases/realistic_continents/namelist_basefile.nml')
 nml = f90nml.read(namelist_name)
 exp.namelist = nml
 


### PR DESCRIPTION
Having attempted to test the external_namelist pull request, I now agree that it is somewhat confusing to have a base namelist which changes parameters that are not relevant for all configurations.

I suggest we instead provide an example of how namelist options can be read in for a case where we currently have 2 scripts doing almost the same experiment. I've chosen the realistic_continents case, and moved the shared parameters to a common fortran namelist to be read in, and kept the differences between the two in the python scripts. I have tested that the results are the same as when the current master is used. 

Thoughts welcome! - I'm still happy to go back through the previous pull request and locate the differences, but I now see the advantages in having python scripts which include only relevant parameter changes. Apologies for the late change of heart!

If no-one dislikes this way, I'll merge this tomorrow and delete the previous pull request.