### PR TITLE
Bug fix in idealized_moist_phys

### DIFF
--- a/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
+++ b/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
@@ -254,7 +254,7 @@ integer ::           &
      id_cape,        &
      id_cin
 
-integer, allocatable, dimension(:,:) :: & convflag ! indicates which qe convection subroutines are used
+integer, allocatable, dimension(:,:) :: convflag ! indicates which qe convection subroutines are used
 real,    allocatable, dimension(:,:) :: rad_lat, rad_lon
 real,    allocatable, dimension(:) :: pref, p_half_1d, ln_p_half_1d, p_full_1d,ln_p_full_1d !s pref is a reference pressure profile, which in 2006 MiMA is just the initial full pressure levels, and an extra level with the reference surface pressure. Others are only necessary to calculate pref.
 real,    allocatable, dimension(:,:) :: capeflag !s Added for Betts Miller scheme (rather than the simplified Betts Miller scheme).


### PR DESCRIPTION
I think this ampersand is a (possibly silent) bug in moist_phys.  ifort seems to skip over it, but gfortran fails to compile.

**I HAVE NOT YET VERIFIED BITWISE RESULTS AFTER REMOVING THIS**