### PR TITLE
RRTM dt-rad bug-fix

### DIFF
--- a/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
+++ b/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
@@ -345,12 +345,18 @@
 
           deg2rad = acos(0.)/90.
 
-          dt_last = -real(dt_rad) !make sure we are computing radiation at the first time step
-
           ncols_rrt = ncols/lonstep
           nlay_rrt  = nlay
 
           call get_time(Time_step,time_step_seconds)
+
+          if (dt_rad .le. 0.) then
+              dt_rad = time_step_seconds !Make sure that dt_rad is set if it is not specified in the namelist
+          endif
+
+          dt_last = -real(dt_rad) !make sure we are computing radiation at the first time step
+
+
 
 	    if (dt_rad .gt. time_step_seconds) then
 	        res=mod(dt_rad, time_step_seconds)


### PR DESCRIPTION
If `dt_rad` is unset in the rrtm-radiation namelist, then default value is 0, and so you get a seg fault. Now changed so that if `dt_rad` is unset it takes its value from `dt_atmos`.