### PR TITLE
Bug fix from Paul O'Gorman, received by Geoff on August 3rd 2018.

### DIFF
--- a/src/atmos_param/diffusivity/diffusivity.F90
+++ b/src/atmos_param/diffusivity/diffusivity.F90
@@ -145,7 +145,7 @@ real    :: ampns_max           = 1.0E20  ! limit to reduction factor
 logical :: do_entrain          =.true.
 logical :: do_simple           =.false.
 
-logical :: use_pog_bug_fix     =.false.
+logical :: use_pog_bug_fix     =.true.
 
 namelist /diffusivity_nml/ fixed_depth, depth_0, frac_inner,&
                            rich_crit_pbl, entr_ratio, parcel_buoy,&

--- a/src/atmos_param/diffusivity/diffusivity.F90
+++ b/src/atmos_param/diffusivity/diffusivity.F90
@@ -145,12 +145,14 @@ real    :: ampns_max           = 1.0E20  ! limit to reduction factor
 logical :: do_entrain          =.true.
 logical :: do_simple           =.false.
 
+logical :: use_pog_bug_fix     =.true.
+
 namelist /diffusivity_nml/ fixed_depth, depth_0, frac_inner,&
                            rich_crit_pbl, entr_ratio, parcel_buoy,&
                            znom, free_atm_diff, free_atm_skyhi_diff,&
                            pbl_mcm, rich_crit_diff, mix_len, rich_prandtl,&
                            background_m, background_t, ampns, ampns_max, &
-                           do_entrain, do_simple
+                           do_entrain, do_simple, use_pog_bug_fix
 
 !=======================================================================
 
@@ -497,13 +499,16 @@ do k = 2, nlev
     k_t(:,:,k) = k_t_ref*factor
   end where
 
-! POG change: avoid possibility of k_m and k_t set to non-zero values above PBL
-! due to use of maxval(h_inner) above 
-  where(zm(:,:,k) >= h) 
-    k_m(:,:,k) = 0
-    k_t(:,:,k) = 0
-  end where
-! end POG change
+
+  if(use_pog_bug_fix) then
+   ! POG change: avoid possibility of k_m and k_t set to non-zero values above PBL
+   ! due to use of maxval(h_inner) above 
+     where(zm(:,:,k) >= h) 
+       k_m(:,:,k) = 0
+       k_t(:,:,k) = 0
+     end where
+   ! end POG change
+  endif
 
 end do
 

--- a/src/atmos_param/diffusivity/diffusivity.F90
+++ b/src/atmos_param/diffusivity/diffusivity.F90
@@ -496,6 +496,15 @@ do k = 2, nlev
     k_m(:,:,k) = k_m_ref*factor
     k_t(:,:,k) = k_t_ref*factor
   end where
+
+! POG change: avoid possibility of k_m and k_t set to non-zero values above PBL
+! due to use of maxval(h_inner) above 
+  where(zm(:,:,k) >= h) 
+    k_m(:,:,k) = 0
+    k_t(:,:,k) = 0
+  end where
+! end POG change
+
 end do
 
 return

--- a/src/atmos_param/diffusivity/diffusivity.F90
+++ b/src/atmos_param/diffusivity/diffusivity.F90
@@ -145,7 +145,7 @@ real    :: ampns_max           = 1.0E20  ! limit to reduction factor
 logical :: do_entrain          =.true.
 logical :: do_simple           =.false.
 
-logical :: use_pog_bug_fix     =.true.
+logical :: use_pog_bug_fix     =.false.
 
 namelist /diffusivity_nml/ fixed_depth, depth_0, frac_inner,&
                            rich_crit_pbl, entr_ratio, parcel_buoy,&

--- a/src/extra/python/scripts/calendar_calc.py
+++ b/src/extra/python/scripts/calendar_calc.py
@@ -1,4 +1,4 @@
-from netcdftime import utime
+from cftime import utime
 from datetime import  datetime
 from cmip_time import FakeDT
 import numpy as np

--- a/src/extra/python/scripts/create_co2_timeseries.py
+++ b/src/extra/python/scripts/create_co2_timeseries.py
@@ -3,7 +3,7 @@ import numpy as np
 import create_timeseries as cts
 
 #create grid
-manual_grid_option=True
+manual_grid_option=False
 
 lons,lats,lonbs,latbs,nlon,nlat,nlonb,nlatb=cts.create_grid(manual_grid_option)
 


### PR DESCRIPTION
Paul's explanation is below:
******
I found a problem with the old boundary-layer diffusivity module that
is used in the  FMS "gray-radiation" code.

The issue is that the diffusivity can be set to non-zero spurious
values above the boundary layer when the boundary-layer height varies
a lot over a processor domain. Fortunately this doesn't seem to
strongly affect the climate in the kinds of simulations I have run
with the GCM. But a knock-on effect is that simulation output can
depend on the processor decomposition used.
******