### PR TITLE
Change default 'equinox_day' value in two_stream_gray 

### DIFF
--- a/src/atmos_param/two_stream_gray_rad/two_stream_gray_rad.F90
+++ b/src/atmos_param/two_stream_gray_rad/two_stream_gray_rad.F90
@@ -80,8 +80,8 @@ real    :: linear_tau      = 0.1
 real    :: wv_exponent     = 4.0
 real    :: solar_exponent  = 4.0
 logical :: do_seasonal     = .false.
-integer :: solday          = -10 !s Day of year to run perpetually if do_seasonal=True and solday>0
-real    :: equinox_day     = 0.0 !s Fraction of year [0,1] where NH autumn equinox occurs (only really useful if calendar has defined months).
+integer :: solday          = -10  !s Day of year to run perpetually if do_seasonal=True and solday>0
+real    :: equinox_day     = 0.75 !s Fraction of year [0,1] where NH autumn equinox occurs (only really useful if calendar has defined months).
 logical :: use_time_average_coszen = .false. !s if .true., then time-averaging is done on coszen so that insolation doesn't depend on timestep
 real    :: dt_rad_avg     = -1
 


### PR DESCRIPTION
Change default 'equinox_day' value in two_stream_gray from 0.0 to 0.75 inline with Socrates and RRTM.  Addresses Issue #66 . 