### PR TITLE
Restructuring how Socrates code is integrated, and bug fixing

### DIFF
--- a/exp/test_cases/socrates_test/socrates_aquaplanet.py
+++ b/exp/test_cases/socrates_test/socrates_aquaplanet.py
@@ -84,6 +84,8 @@ exp.namelist = namelist = Namelist({
         'dt_rad':3600,
         'store_intermediate_rad':True,
         'chunk_size': 16,
+        'use_pressure_interp_for_half_levels':False,
+        'tidally_locked':False
     }, 
     'idealized_moist_phys_nml': {
         'do_damping': True,

--- a/exp/test_cases/socrates_test/socrates_aquaplanet.py
+++ b/exp/test_cases/socrates_test/socrates_aquaplanet.py
@@ -22,6 +22,10 @@ cb = SocratesCodeBase.from_directory(GFDL_BASE)
 
 # create an Experiment object to handle the configuration of model parameters
 # and output diagnostics
+
+exp = Experiment('soc_test_aquaplanet', codebase=cb)
+exp.clear_rundir()
+
 inputfiles = [os.path.join(GFDL_BASE,'input/rrtm_input_files/ozone_1990.nc')]
 
 #Tell model how to write diagnostics
@@ -56,9 +60,11 @@ diag.add_field('socrates', 'soc_toa_sw', time_avg=True)
 #diag.add_field('socrates', 'soc_coszen', time_avg=True) 
 #diag.add_field('socrates', 'soc_spectral_olr', time_avg=True)
 
+exp.diag_table = diag
+exp.inputfiles = inputfiles
 
 #Define values for the 'core' namelist
-namelist = Namelist({
+exp.namelist = namelist = Namelist({
     'main_nml':{
      'days'   : 30,
      'hours'  : 0,
@@ -183,15 +189,6 @@ if __name__=="__main__":
         cb.compile()
         #Set up the experiment object, with the first argument being the experiment name.
         #This will be the name of the folder that the data will appear in.
-
-        exp = Experiment('soc_test_aquaplanet', codebase=cb)
-        exp.clear_rundir()
-
-        exp.diag_table = diag
-        exp.inputfiles = inputfiles
-
-        exp.namelist = namelist.copy()
-
         exp.run(1, use_restart=False, num_cores=NCORES)
         for i in range(2,121):
             exp.run(i, num_cores=NCORES)

--- a/exp/test_cases/trip_test/trip_test_functions.py
+++ b/exp/test_cases/trip_test/trip_test_functions.py
@@ -6,7 +6,7 @@ or only change the test cases it expects to (e.g. a bug fix will change the resu
 When you submit a new pull request, please run this test and report the results in the pull request.
 """
 import numpy as np
-from isca import Experiment, IscaCodeBase, FailedRunError, GFDL_BASE, DiagTable
+from isca import Experiment, IscaCodeBase, SocratesCodeBase, FailedRunError, GFDL_BASE, DiagTable
 from isca.util import exp_progress
 import xarray as xar
 import pdb
@@ -73,6 +73,12 @@ def get_nml_diag(test_case_name):
         input_files = exp_temp.inputfiles
         nml_out = exp_temp.namelist        
 
+    if 'socrates_aquaplanet' in test_case_name:
+        sys.path.insert(0, os.path.join(GFDL_BASE, 'exp/test_cases/socrates_test/'))
+        from socrates_aquaplanet import exp as exp_temp
+        input_files = exp_temp.inputfiles
+        nml_out = exp_temp.namelist       
+
     if 'top_down_test' in test_case_name:
         sys.path.insert(0, os.path.join(GFDL_BASE, 'exp/test_cases/top_down_test/'))
         from top_down_test import namelist as nml_out
@@ -95,7 +101,7 @@ def get_nml_diag(test_case_name):
 def list_all_test_cases_implemented_in_trip_test():
 
     #List of test cases to check
-    exps_implemented = ['axisymmetric', 'bucket_model', 'frierson', 'giant_planet', 'held_suarez', 'MiMA', 'realistic_continents_fixed_sst', 'realistic_continents_variable_qflux', 'top_down_test', 'variable_co2_grey', 'variable_co2_rrtm']
+    exps_implemented = ['axisymmetric', 'bucket_model', 'frierson', 'giant_planet', 'held_suarez', 'MiMA', 'realistic_continents_fixed_sst', 'realistic_continents_variable_qflux', 'socrates_aquaplanet', 'top_down_test', 'variable_co2_grey', 'variable_co2_rrtm']
 
     return exps_implemented
 
@@ -148,7 +154,10 @@ def conduct_comparison_on_test_case(base_commit, later_commit, test_case_name, r
     #Do the run for each of the commits in turn
     for s in [base_commit, later_commit]:
         exp_name = test_case_name+'_trip_test_21_'+s
-        cb = IscaCodeBase(repo=repo_to_use, commit=s)
+        if 'socrates' in test_case_name:
+            cb = SocratesCodeBase(repo=repo_to_use, commit=s)
+        else:
+            cb = IscaCodeBase(repo=repo_to_use, commit=s)
         cb.compile()
         exp = Experiment(exp_name, codebase=cb)
         exp.namelist = nml_use.copy()

--- a/src/atmos_param/socrates/interface/socrates_config_mod.f90
+++ b/src/atmos_param/socrates/interface/socrates_config_mod.f90
@@ -18,6 +18,10 @@ LOGICAL :: l_planet_grey_surface = .TRUE.
   
   REAL :: stellar_constant = 1368.22 !Consistent with RRTM default
   LOGICAL :: tidally_locked = .FALSE.
+  !Options for annual-mean incoming solar, as prescribed in Frierson's grey scheme.
+  LOGICAL :: frierson_solar_rad = .FALSE.
+  REAL    :: del_sol         = 1.4
+  REAL    :: del_sw          = 0.0
   LOGICAL :: socrates_hires_mode = .FALSE.  !If false then run in 'GCM mode', if true then uses high-res spectral files
   character(len=256) :: lw_spectral_filename='unset'
   character(len=256) :: lw_hires_spectral_filename='unset'
@@ -122,6 +126,7 @@ LOGICAL :: l_planet_grey_surface = .TRUE.
                              hfc134a_mix_ratio, &
                              inc_h2o, inc_co2, inc_co, inc_o3, inc_n2o, inc_ch4, inc_o2, &
                              inc_so2, inc_cfc11, inc_cfc12, inc_cfc113, inc_hcfc22, inc_hfc134a, &
-                             use_pressure_interp_for_half_levels
+                             use_pressure_interp_for_half_levels,  &
+                             frierson_solar_rad, del_sol, del_sw
 
 end module socrates_config_mod

--- a/src/atmos_param/socrates/interface/socrates_interface.F90
+++ b/src/atmos_param/socrates/interface/socrates_interface.F90
@@ -266,12 +266,12 @@ write(stdlog_unit, socrates_rad_nml)
          'watts/m2', missing_value=missing_value               )
 
     id_soc_flux_lw = &
-         register_diag_field ( soc_mod_name, 'soc_flux_lw', axes(1:3), Time, &
+         register_diag_field ( soc_mod_name, 'soc_flux_lw', (/axes(1),axes(2),axes(4)/), Time, &
          'socrates Net LW flux (up)', &
          'watts/m2', missing_value=missing_value               )
 
     id_soc_flux_sw = &
-         register_diag_field ( soc_mod_name, 'soc_flux_sw', axes(1:3), Time, &
+         register_diag_field ( soc_mod_name, 'soc_flux_sw', (/axes(1),axes(2),axes(4)/), Time, &
          'socrates Net SW flux (up)', & 
          'watts/m2', missing_value=missing_value               )
 
@@ -332,11 +332,11 @@ write(stdlog_unit, socrates_rad_nml)
         endif
 
         if (id_soc_flux_lw > 0) then 
-            allocate(thd_lw_flux_net_store(size(lonb,1)-1, size(latb,2)-1, num_levels))
+            allocate(thd_lw_flux_net_store(size(lonb,1)-1, size(latb,2)-1, num_levels+1))
         endif 
 
         if (id_soc_flux_sw > 0) then 
-            allocate(thd_sw_flux_net_store(size(lonb,1)-1, size(latb,2)-1, num_levels))
+            allocate(thd_sw_flux_net_store(size(lonb,1)-1, size(latb,2)-1, num_levels+1))
         endif 
 
         if (id_soc_olr > 0) then 
@@ -658,11 +658,11 @@ write(stdlog_unit, socrates_rad_nml)
         ENDDO
 
           ! Set output arrays
-          output_flux_up(:,:,:) = reshape(soc_flux_up(:,:),(/si,sj,sk /))
-          output_flux_down(:,:,:) = reshape(soc_flux_down(:,:),(/si,sj,sk /))          
+          output_flux_up(:,:,:) = reshape(soc_flux_up(:,:),(/si,sj,sk+1 /))
+          output_flux_down(:,:,:) = reshape(soc_flux_down(:,:),(/si,sj,sk+1 /))          
 
           if(present(output_flux_direct)) then
-              output_flux_direct(:,:,:) = reshape(soc_flux_direct(:,:),(/si,sj,sk /))          
+              output_flux_direct(:,:,:) = reshape(soc_flux_direct(:,:),(/si,sj,sk+1 /))          
           endif
           
           output_heating_rate(:,:,:) = reshape(soc_heating_rate(:,:),(/si,sj,sk /))
@@ -693,14 +693,15 @@ subroutine run_socrates(Time, Time_diag, rad_lat, rad_lon, temp_in, q_in, t_surf
     integer(i_def) :: n_profile, n_layer
 
     real(r_def), dimension(size(temp_in,1), size(temp_in,2)) :: t_surf_for_soc, rad_lat_soc, rad_lon_soc, albedo_soc
-    real(r_def), dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)) :: tg_tmp_soc, q_soc, ozone_soc, co2_soc, p_full_soc, output_heating_rate_sw, output_heating_rate_lw, output_heating_rate_total, output_soc_flux_sw_down, output_soc_flux_sw_up, output_soc_flux_lw_down, output_soc_flux_lw_up, z_full_soc
-    real(r_def), dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)+1) :: p_half_soc, t_half_out, z_half_soc
+    real(r_def), dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)) :: tg_tmp_soc, q_soc, ozone_soc, co2_soc, p_full_soc, output_heating_rate_sw, output_heating_rate_lw, output_heating_rate_total, z_full_soc
+    real(r_def), dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)+1) :: p_half_soc, t_half_out, z_half_soc,output_soc_flux_sw_down, output_soc_flux_sw_up, output_soc_flux_lw_down, output_soc_flux_lw_up
 
     logical :: soc_lw_mode, used
     integer :: seconds, days, year_in_s
     real :: r_seconds, r_days, r_total_seconds, frac_of_day, frac_of_year, gmt, time_since_ae, rrsun, dt_rad_radians, day_in_s, r_solday, r_dt_rad_avg
     real, dimension(size(temp_in,1), size(temp_in,2)) :: coszen, fracsun, surf_lw_net, olr, toa_sw
-    real, dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)) :: ozone_in, co2_in, thd_sw_flux_net, thd_lw_flux_net
+    real, dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)) :: ozone_in, co2_in
+    real, dimension(size(temp_in,1), size(temp_in,2), size(temp_in,3)+1) :: thd_sw_flux_net, thd_lw_flux_net
     type(time_type) :: Time_loc
 
     

--- a/src/atmos_param/socrates/interface/socrates_interface.F90
+++ b/src/atmos_param/socrates/interface/socrates_interface.F90
@@ -925,8 +925,8 @@ subroutine run_socrates(Time, Time_diag, rad_lat, rad_lon, temp_in, q_in, t_surf
             output_heating_rate_lw, output_soc_flux_lw_down, output_soc_flux_lw_up, output_soc_spectral_olr = outputted_soc_spectral_olr, t_half_level_out = t_half_out)
 
        tg_tmp_soc = tg_tmp_soc + output_heating_rate_lw*delta_t !Output heating rate in K/s, so is a temperature tendency
-       surf_lw_down(:,:) = REAL(output_soc_flux_lw_down(:,:, n_layer))
-       surf_lw_net(:,:) = REAL(output_soc_flux_lw_up(:,:,n_layer) - output_soc_flux_lw_down(:,:, n_layer))
+       surf_lw_down(:,:) = REAL(output_soc_flux_lw_down(:,:, n_layer+1))
+       surf_lw_net(:,:) = REAL(output_soc_flux_lw_up(:,:,n_layer+1) - output_soc_flux_lw_down(:,:, n_layer+1))
        olr(:,:) = REAL(output_soc_flux_lw_up(:,:,1))
        thd_lw_flux_net = REAL(output_soc_flux_lw_up - output_soc_flux_lw_down)
 
@@ -940,7 +940,7 @@ subroutine run_socrates(Time, Time_diag, rad_lat, rad_lon, temp_in, q_in, t_surf
             output_heating_rate_sw, output_soc_flux_sw_down, output_soc_flux_sw_up)
 
        tg_tmp_soc = tg_tmp_soc + output_heating_rate_sw*delta_t !Output heating rate in K/s, so is a temperature tendency
-       net_surf_sw_down(:,:) = REAL(output_soc_flux_sw_down(:,:, n_layer)-output_soc_flux_sw_up(:,:,n_layer) )
+       net_surf_sw_down(:,:) = REAL(output_soc_flux_sw_down(:,:, n_layer+1)-output_soc_flux_sw_up(:,:,n_layer+1) )
        toa_sw(:,:) = REAL(output_soc_flux_sw_down(:,:,1)-output_soc_flux_sw_up(:,:,1))
        thd_sw_flux_net = REAL(output_soc_flux_sw_up - output_soc_flux_sw_down)
 

--- a/src/extra/python/isca/__init__.py
+++ b/src/extra/python/isca/__init__.py
@@ -32,6 +32,12 @@ except:
     GFDL_ENV = socket.getfqdn()
     log.warning('Environment variable GFDL_ENV not set, using "%s".' % GFDL_ENV)
 
+try:
+    GFDL_SOC = os.environ['GFDL_SOC']
+except:
+    # if the user doesn't have the SOC variable set, then use None
+    GFDL_SOC = None
+    log.warning('Environment variable GFDL_SOC not set, but this is only required if using SocratesCodebase. Setting to '+str(GFDL_SOC))
 
 def get_env_file(env=GFDL_ENV):
     filepath = os.path.join(GFDL_BASE, 'src', 'extra', 'env', env)

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -297,7 +297,6 @@ class SocratesCodeBase(CodeBase):
             link_correct = os.path.exists(socrates_desired_location+'/src/')
             if link_correct:
                 socrates_code_in_desired_location=True
-                self.log.info('Socrates source code already in correct place. Continuing.')                
             else:
                 socrates_code_in_desired_location=False                
                 if os.path.islink(socrates_desired_location):
@@ -310,14 +309,15 @@ class SocratesCodeBase(CodeBase):
             self.log.info('Socrates source code symlink does not exist. Creating.')
 
         # If socrates is not in the right place already, then attempt to make symlink to location of code provided by GFDL_SOC
-        if GFDL_SOC is not None and not socrates_code_in_desired_location:
-            sh.ln('-s', GFDL_SOC, socrates_desired_location)
-        elif GFDL_SOC is None and not socrates_code_in_desired_location:
-            error_mesg = 'Socrates code is required for SocratesCodebase, but source code is not provided in location GFDL_SOC='+ str(GFDL_SOC)
-            self.log.error(error_mesg)
-            raise OSError(error_mesg)
-        elif socrates_code_in_desired_location:
+        if socrates_code_in_desired_location:
             self.log.info('Socrates source code already in correct place. Continuing.')
+        else:
+            if GFDL_SOC is not None:
+                sh.ln('-s', GFDL_SOC, socrates_desired_location)
+            elif GFDL_SOC is None:
+                error_mesg = 'Socrates code is required for SocratesCodebase, but source code is not provided in location GFDL_SOC='+ str(GFDL_SOC)
+                self.log.error(error_mesg)
+                raise OSError(error_mesg)
 
     def __init__(self, *args, **kwargs):
         super(SocratesCodeBase, self).__init__(*args, **kwargs)

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -5,7 +5,7 @@ import socket
 from jinja2 import Environment, FileSystemLoader
 import sh
 
-from isca import GFDL_WORK, GFDL_BASE, _module_directory, get_env_file
+from isca import GFDL_WORK, GFDL_BASE, GFDL_SOC, _module_directory, get_env_file
 from .loghandler import Logger
 from .helpers import url_to_folder, destructive, useworkdir, mkdir, cd, git, P, git_run_in_directory
 
@@ -288,9 +288,41 @@ class SocratesCodeBase(CodeBase):
         self.compile_flags.append('-DRRTM_NO_COMPILE')
         self.log.info('RRTM compilation disabled.')
 
+    def simlink_to_soc_code(self):
+        #Make symlink to socrates source code if one doesn't already exist.
+        socrates_desired_location = self.codedir+'/src/atmos_param/socrates/src/trunk'
+
+        #First check if socrates is in correct place already
+        if os.path.exists(socrates_desired_location):
+            link_correct = os.path.exists(socrates_desired_location+'/src/')
+            if link_correct:
+                socrates_code_in_desired_location=True
+                self.log.info('Socrates source code already in correct place. Continuing.')                
+            else:
+                socrates_code_in_desired_location=False                
+                if os.path.islink(socrates_desired_location):
+                    self.log.info('Socrates source code symlink is in correct place, but is to incorrect location. Trying to correct.')
+                    os.unlink(socrates_desired_location)
+                else:
+                    self.log.info('Socrates source code is in correct place, but folder structure is wrong. Contents of the folder '+socrates_desired_location+' should include a src folder.')
+        else:
+            socrates_code_in_desired_location=False
+            self.log.info('Socrates source code symlink does not exist. Creating.')
+
+        # If socrates is not in the right place already, then attempt to make symlink to location of code provided by GFDL_SOC
+        if GFDL_SOC is not None and not socrates_code_in_desired_location:
+            sh.ln('-s', GFDL_SOC, socrates_desired_location)
+        elif GFDL_SOC is None and not socrates_code_in_desired_location:
+            error_mesg = 'Socrates code is required for SocratesCodebase, but source code is not provided in location GFDL_SOC='+ str(GFDL_SOC)
+            self.log.error(error_mesg)
+            raise OSError(error_mesg)
+        elif socrates_code_in_desired_location:
+            self.log.info('Socrates source code already in correct place. Continuing.')
+
     def __init__(self, *args, **kwargs):
         super(SocratesCodeBase, self).__init__(*args, **kwargs)
         self.disable_rrtm()
+        self.simlink_to_soc_code()
 
 class GreyCodeBase(CodeBase):
     """The Frierson model.


### PR DESCRIPTION
# Fortran Changes

As mentioned in #61 , I found a disagreement in results between 6c4289d and 3d1030e. Some of this was down to #63's changes to the diffusivity mod. But I traced the other changes to d3f9678, which changed the way that `socrates_interface` outputted fluxes. It turns out the older version was more correct, and d3f9678 introduced a bug. The problem created by d3f9678 was that `socrates_calc` spat out fluxes on half levels, but I was capturing this output with 1 fewer levels than required. The upshot of this was that versions more from d3f9678 and newer have been passing out the surface fluxes from 1 level up in the atmosphere, rather than from the surface. This has lead to lower atmospheric temperatures and lower near-surface specific humidity values. The changes included in this P/R fix these problems. 

# Socrates Codebase changes:

In order to complete the above testing, I wanted to make the socrates test case work as part of the trip tests. To do this, I created a new environment variable called `GFDL_SOC`, which points to the location of the socrates source code (meaning this can be kept outside of the Isca folder on a local machine). Upon creation of the `SocratesCodebase` object, a sym-link is created from the location of the Socrates source to `Isca/src/atmos_param/socrates/src/trunk`, which is the location expected for the Socrates source code. This allows the socrates test case to work with the trip test. I will update the Socrates Readme accordingly.