### PR TITLE
Bug in interpolator when using input files with no time dimension.

### DIFF
--- a/src/atmos_shared/interpolator/interpolator.F90
+++ b/src/atmos_shared/interpolator/interpolator.F90
@@ -3002,9 +3002,9 @@ if (associated (clim_type%pmon_pyear)) then
 endif
 
 !! RSH mod   
-if(  .not. (clim_type%TIME_FLAG .eq. LINEAR  .and.    &
+if(  .not. ((clim_type%TIME_FLAG .eq. LINEAR  .and.    &
 !     read_all_on_init)) .or. clim_type%TIME_FLAG .eq. BILINEAR  ) then
-      read_all_on_init)  ) then
+      read_all_on_init).or. ( clim_type%TIME_FLAG .eq. NOTIME ))  ) then
  call mpp_close(clim_type%unit)
 endif
 


### PR DESCRIPTION
@ntlewis reported a problem when supplying equilibrium temperatures from a file when using hs_forcing. The problem was that, when supplying input files with no time dimension, the following error was appearing:
`FATAL: MPP_WRITE: invalid unit number.`
It turns out that this is because, in the case when an input file has no time axis, the interpolator closes the input file once it's been read, on line 1056 below. This means that, because having no time axis means `interpolator_end` meets the original condition on line 3055, the interpolator tries to close this file again, which it's already done. Hence the error. 

I have updated the condition in `interpolator_end` to modify when the `mpp_close` command is called. This has fixed the problem.
