### PR TITLE
Bristol BlueCrystal 4 setup

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -107,6 +107,10 @@ Once the code has sucessfully compiled, the script will continue on to run the m
 
 Once you've got an environment file that works for your machine saved in `src/extra/env`, all of the test cases should now compile and run - you're now ready to start running your own experiments!
 
+## Site-specific help
+
+There are some site-specific guides to running Isca on your local system located in the directory [exp/site_specific/](https://github.com/ExeClim/Isca/tree/master/exp/site_specific).
+
 # License
 
 Isca is distributed under a GNU GPLv3 license. See the `LICENSE` file for details. 

--- a/exp/site_specific/bristol/ReadMe_Bristol.md
+++ b/exp/site_specific/bristol/ReadMe_Bristol.md
@@ -9,12 +9,11 @@ First, to enable `git`, run:
 $ module load git
 ```
 
-Now you can clone Will Seviour's fork of Isca, and switch to the UoB branch:
+Now you can clone the Isca repository:
 
 ```{bash}
-$ git clone git@github.com:wseviour/Isca.git
+$ git clone git@github.com:ExeClim/Isca.git
 $ cd Isca
-$ git checkout remotes/origin/uob_master
 ```
 
 Before you can run Isca, you'll need to load the Anaconda python distribution:

--- a/exp/site_specific/bristol/ReadMe_Bristol.md
+++ b/exp/site_specific/bristol/ReadMe_Bristol.md
@@ -1,0 +1,74 @@
+
+# Instructions for running Isca on BlueCrystal 4 at Bristol
+
+These instructions are intended to get you up-and-running with a simple Held-Suarez test case. They assume you are starting with a default user environment on BlueCrystal 4, so some changes might be needed if you have already modified your environment. Please don't hesistate to get in touch (w.seviour@bristol.ac.uk) if you have any questions.
+
+First, to enable `git`, run:
+
+```{bash}
+$ module load git
+```
+
+Now you can clone Will Seviour's fork of Isca, and switch to the UoB branch:
+
+```{bash}
+$ git clone git@github.com:wseviour/Isca.git
+$ cd Isca
+$ git checkout remotes/origin/uob_master
+```
+
+Before you can run Isca, you'll need to load the Anaconda python distribution:
+
+```{bash}
+$ module load languages/anaconda3
+```
+
+Next we'll make a conda environment for Isca (this means it will have all the right versions of the various packages on which it depends):
+
+```{bash}
+$ conda create -n isca_env python ipython
+$ source activate isca_env
+(isca_env) $ cd Isca/src/extra/python
+(isca_env) $ pip install -r requirements.txt
+
+Successfully installed MarkupSafe-1.0 f90nml jinja2-2.9.6 numpy-1.13.3 pandas-0.21.0 python-dateutil-2.6.1 pytz-2017.3 sh-1.12.14 six-1.11.0 xarray-0.9.6
+
+(isca_env) $ pip install -e .
+...
+Successfully installed Isca
+```
+
+Finally, we'll need to update the `~/.bashrc` file. Add the following lines:
+
+```{bash}
+# directory of the Isca source code
+export GFDL_BASE=$HOME/Isca
+# "environment" configuration for bc4
+export GFDL_ENV=bristol-bc4
+# temporary working directory used in running the model
+export GFDL_WORK=/mnt/storage/home/$USER/scratch/Isca_work
+# directory for storing model output
+export GFDL_DATA=/mnt/storage/home/$USER/scratch/Isca_data
+```
+
+Then make the `Isca_work` and `Isca_data` directories:
+
+```{bash}
+(isca_env) $ mkdir -p /mnt/storage/home/$USER/scratch/Isca_work
+(isca_env} $ mkdir -p /mnt/storage/home/$USER/scratch/Isca_data
+(isca_env) $ bash
+```
+Now everything should be set up and we can try a test run. The following should compile and run 12 months of a Held-Suarez test case, at T42 resolution spread over 16 cores. 
+
+```{bash}
+(isca_env) $ cd Isca/exp/site-specific
+(isca_env) $ sbatch isca_slurm_job.sh
+```
+
+This should produce a slurm file showing the progress as it compiles and runs. To track the progress:
+
+```{bash}
+(isca_env) $ tail -f slurm_*.o
+```
+
+All being well, after about 20 minutes the job should complete, and you'll find some output files in `/mnt/storage/home/$USER/scratch/Isca_data`.

--- a/exp/site_specific/bristol/isca_slurm_job.sh
+++ b/exp/site_specific/bristol/isca_slurm_job.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -l
+
+#SBATCH --job-name=held_suarez_test_case
+#SBATCH --partition=veryshort
+#SBATCH --time=1:00:00
+#SBATCH --nodes=1
+#number of tasks ~ processes per node
+#SBATCH --ntasks-per-node=16
+#number of cpus (cores) per task (process)
+#SBATCH --cpus-per-task=1
+#SBATCH --output=slurm_%j.o
+
+echo Running on host `hostname`
+echo Time is `date`
+echo Directory is `pwd`
+
+
+module purge
+source $HOME/.bashrc
+source $GFDL_BASE/src/extra/env/bristol-bc4
+source activate isca_env
+
+
+
+$HOME/.conda/envs/isca_env/bin/python $GFDL_BASE/exp/test_cases/held_suarez/held_suarez_test_case.py

--- a/src/extra/env/bristol-bc4
+++ b/src/extra/env/bristol-bc4
@@ -1,0 +1,13 @@
+echo loadmodules for Bristol Bluecrystal 4
+
+module purge
+
+module load libs/netcdf/4.4.1.1.MPI
+module load build/gcc-7.2.0
+module load tools/git/2.18.0
+
+export CPATH=$CPATH:/mnt/storage/software/libraries/intel/netcdf-4.4.1.1-mpi/include
+
+export F90=mpiifort
+export CC=mpiicc
+


### PR DESCRIPTION
Adds the setup for running Isca on Bristol's BlueCrystal 4 cluster. I have just added an env file, a test slurm job for running on BlueCrystal4, and a Bristol-specific ReadMe to help new users here. I also added a pointer to the site-specific ReadMes in the main ReadMe, since I thought they are a bit difficult to find.  

