### PR TITLE
Correct the units of temperature and moisture diffusion tendency

### DIFF
--- a/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
+++ b/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
@@ -767,9 +767,9 @@ if(turb) then
    id_diff_dt_vg = register_diag_field(mod_name, 'dt_vg_diffusion',        &
         axes(1:3), Time, 'meridional wind tendency from diffusion','m/s^2')
    id_diff_dt_tg = register_diag_field(mod_name, 'dt_tg_diffusion',        &
-        axes(1:3), Time, 'temperature diffusion tendency','T/s')
+        axes(1:3), Time, 'temperature diffusion tendency','K/s')
    id_diff_dt_qg = register_diag_field(mod_name, 'dt_qg_diffusion',        &
-        axes(1:3), Time, 'moisture diffusion tendency','T/s')
+        axes(1:3), Time, 'moisture diffusion tendency','kg/kg/s')
 endif
 
    id_rh = register_diag_field ( mod_name, 'rh', &


### PR DESCRIPTION
Correct the units of temperature and moisture diffusion tendency in `idealized_moist_phys.F90`. The  units of `dt_tg_diffusion`  and `dt_qg_diffusion`  should be `K/s` and `kg/kg/s`, respectively.