### PR TITLE
Added frierson insolation profile option to rrtm_radiation.f90

### DIFF
--- a/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
+++ b/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
@@ -164,8 +164,8 @@
 !!!!!! mp586 added for annual mean insolation!!!!!
 
 		logical            :: frierson_solar_rad =.false.
-		real(kind=rb)	   :: del_sol
-		real(kind=rb)	   :: del_sw
+		real(kind=rb)	   :: del_sol = 0.95 ! frierson 2006 default = 1.4, but 0.95 gets the curve closer to the annual mean insolation 
+		real(kind=rb)	   :: del_sw = 0.0 !frierson 2006 default 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -206,7 +206,7 @@
              &h2o_lower_limit,temp_lower_limit,temp_upper_limit,co2ppmv, &
              &do_fixed_water,fixed_water,fixed_water_pres,fixed_water_lat, &
              &slowdown_rad, &
-             &store_intermediate_rad, do_rad_time_avg, frierson_solar_rad, dt_rad, dt_rad_avg, & !mp586 added frierson_solar_rad for annual mean insolation
+             &store_intermediate_rad, do_rad_time_avg, frierson_solar_rad, del_sol, del_sw, dt_rad, dt_rad_avg, & !mp586 added frierson_solar_rad, del_sol, del_sw for annual mean insolation
              &lonstep, do_zm_tracers, do_zm_rad, &
              &do_precip_albedo, precip_albedo_mode, precip_albedo, precip_lat,&
              &do_read_co2, co2_file, co2_variable_name, use_dyofyr, solrad, &
@@ -647,9 +647,6 @@
 
 !!!!! mp586 addition for annual mean insolation !!!!!
 !!!! following https://github.com/sit23/Isca/blob/master/src/atmos_param/socrates/interface/socrates_interface.F90#L888 !!!!
-
-		del_sol = 0.95 ! mp586: frierson 2006 default = 1.4, but 0.95 gets the curve closer to the annual mean insolation 
-		del_sw = 0.0 !frierson 2006 default 
 
        	if (frierson_solar_rad .eq. .true.) then
             p2     = (1. - 3.*sin(lat(:,:))**2)/4.

--- a/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
+++ b/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
@@ -160,6 +160,15 @@
         integer(kind=im)   :: dt_rad_avg = -1                 ! If averaging, over what time? dt_rad_avg=dt_rad if dt_rad_avg<=0
         integer(kind=im)   :: lonstep=1                       ! Subsample fields along longitude
                                                               !  for faster radiation calculation
+
+!!!!!! mp586 added for annual mean insolation!!!!!
+
+		logical            :: frierson_solar_rad =.false.
+		real(kind=rb)	   :: del_sol
+		real(kind=rb)	   :: del_sw
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 ! some fancy radiation tweaks  
         real(kind=rb)      :: slowdown_rad = 1.0              ! factor do simulate slower seasonal cycle: >1 means faster, <1 slower
         logical            :: do_zm_rad=.false.               ! Only compute zonal mean radiation
@@ -197,7 +206,7 @@
              &h2o_lower_limit,temp_lower_limit,temp_upper_limit,co2ppmv, &
              &do_fixed_water,fixed_water,fixed_water_pres,fixed_water_lat, &
              &slowdown_rad, &
-             &store_intermediate_rad, do_rad_time_avg, dt_rad, dt_rad_avg, &
+             &store_intermediate_rad, do_rad_time_avg, frierson_solar_rad, dt_rad, dt_rad_avg, & !mp586 added frierson_solar_rad for annual mean insolation
              &lonstep, do_zm_tracers, do_zm_rad, &
              &do_precip_albedo, precip_albedo_mode, precip_albedo, precip_lat,&
              &do_read_co2, co2_file, co2_variable_name, use_dyofyr, solrad, &
@@ -588,6 +597,7 @@
           real(kind=rb),dimension(size(q,1),size(q,2)) :: albedo_loc
           real(kind=rb),dimension(size(q,1),size(q,2),size(q,3)) :: q_tmp, h2o_vmr
           real(kind=rb),dimension(size(q,1),size(q,2)) :: fracsun
+          real(kind=rb),dimension(size(q,1),size(q,2)) :: p2 !mp586 addition for annual mean insolation
 
 	  integer :: year_in_s
           real :: r_seconds, r_days, r_total_seconds, frac_of_day, frac_of_year, gmt, time_since_ae, rrsun, dt_rad_radians, day_in_s, r_solday, r_dt_rad_avg
@@ -635,6 +645,20 @@
              Time_loc = Time
           endif
 
+!!!!! mp586 addition for annual mean insolation !!!!!
+!!!! following https://github.com/sit23/Isca/blob/master/src/atmos_param/socrates/interface/socrates_interface.F90#L888 !!!!
+
+		del_sol = 0.95 ! mp586: frierson 2006 default = 1.4, but 0.95 gets the curve closer to the annual mean insolation 
+		del_sw = 0.0 !frierson 2006 default 
+
+       	if (frierson_solar_rad .eq. .true.) then
+            p2     = (1. - 3.*sin(lat(:,:))**2)/4.
+            coszen = 0.25 * (1.0 + del_sol * p2 + del_sw * sin(lat(:,:)))
+            rrsun  = 1 ! needs to be set, set to 1 so that stellar_radiation is unchanged in socrates_interface
+       else
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 !
 ! compute zenith angle
 !  this is also an output, so need to compute even if we read radiation from file
@@ -665,6 +689,8 @@
 	     ! Seasonal Cycle: Use astronomical parameters to calculate insolation
 	     call diurnal_solar(lat, lon, gmt, time_since_ae, coszen, fracsun, rrsun)
           end if
+
+   		end if !mp586 addition for annual mean insolation
 
 ! input files: only deal with case where we don't need to call radiation at all
           if(do_read_radiation .and. do_read_sw_flux .and. do_read_lw_flux) then


### PR DESCRIPTION
Insolation Profile from Frierson (2006, https://doi.org/10.1175/JAS3753.1) option added to rrtm_radiation.f90
Activate by setting 
**'frierson_solar_rad': True**
in the rrtm_radiation_nml.
(Default is false) 

NB: Using slightly different parameters than Frierson (2006) because del_sol = 0.95 is the best fit for the annual mean insolation from isca (as opposed to the Frierson 2006 default of 1.4)

[astronomy_calc.pdf](https://github.com/ExeClim/Isca/files/4109766/astronomy_calc.pdf) 
Courtesy of @sit23 for providing the code necessary to compare the Frierson insolation profile with isca's annual mean profile

All trip tests run successfully: 

Results for all of the test cases ran comparing 90f247e and 522ed72 are as follows...
axisymmetric : pass
bucket_model : pass
frierson : pass
giant_planet : pass
held_suarez : pass
MiMA : pass
realistic_continents_fixed_sst : pass
realistic_continents_variable_qflux : pass
top_down_test : pass
variable_co2_grey : pass
variable_co2_rrtm : pass
Congratulations, all tests have passed

