### PR TITLE
Saturation Vapour Pressure Modification

### DIFF
--- a/src/shared/constants/constants.F90
+++ b/src/shared/constants/constants.F90
@@ -90,7 +90,7 @@ real, public, parameter :: RHO0R   = 1.0/RHO0
 real, public, parameter :: RHO_CP  = RHO0*CP_OCEAN
 
 !------------ water vapor constants ---------------
-! <DATA NAME="ES0" TYPE="real" DEFAULT="1.0">
+! <DATA NAME="DEF_ES0" TYPE="real" DEFAULT="1.0">
 !   Humidity factor. Controls the humidity content of the atmosphere through
 !   the Saturation Vapour Pressure expression when using DO_SIMPLE.
 ! </DATA>
@@ -116,7 +116,7 @@ real, public, parameter :: RHO_CP  = RHO0*CP_OCEAN
 !   temp where fresh water freezes
 ! </DATA>
 
-real, public, parameter :: ES0 = 1.0
+real, public, parameter :: DEF_ES0 = 1.0
 real, public, parameter :: RVGAS = 461.50
 real, public, parameter :: CP_VAPOR = 4.0*RVGAS
 real, public, parameter :: DENS_H2O = 1000.
@@ -264,9 +264,10 @@ real, public :: PSTD_MKS    = PSTD_MKS_EARTH
 real, public :: RDGAS  = EARTH_RDGAS
 real, public :: KAPPA = EARTH_KAPPA
 real, public :: CP_AIR = EARTH_CP_AIR
+real, public :: es0 = DEF_ES0
 logical :: earthday_multiple = .false.
 
-namelist/constants_nml/ radius, grav, omega, orbital_period, pstd, pstd_mks, rdgas, kappa, solar_const, earthday_multiple
+namelist/constants_nml/ radius, grav, omega, orbital_period, pstd, pstd_mks, rdgas, kappa, solar_const, earthday_multiple, es0
 
 !-----------------------------------------------------------------------
 ! version and tagname published
@@ -311,7 +312,7 @@ subroutine constants_init
 	else
 	    seconds_per_sol = abs(2*pi / (orbital_rate - omega))
 	endif
-	
+
     CP_AIR = RDGAS/KAPPA
 
     constants_initialised = .true.
@@ -352,4 +353,3 @@ end module constants_mod
 !   </NOTE>
 
 ! </INFO>
-


### PR DESCRIPTION
In the Frierson et al. (2007), Dargan investigated changes in modifying the saturation vapour pressure to obtain:
* Totally dry atmospheres (`es0` = 0)
* Drier atmospheres (`es0` < 1)
* Moist atmospheres (`es0` > 1)

I therefore added the `es0` parameter as a possible namelist option for future investigation.