### PR TITLE
Environments for FASRC (Harvard) and Gekko (NTU Singapore) clusters

### DIFF
--- a/src/extra/env/fasrc
+++ b/src/extra/env/fasrc
@@ -1,0 +1,11 @@
+echo loadmodules for Isca on Harvard FASRC Cluster Cannon/Odyssey
+
+export F90=mpif90; echo $F90;
+export CC=mpicc
+
+module purge
+module load intel/17.0.4-fasrc01
+#module load hdf5/1.10.1-fasrc03
+module load intel/17.0.4-fasrc01 openmpi/2.1.0-fasrc02 netcdf-fortran/4.4.4-fasrc06
+module load zlib/1.2.8-fasrc07
+#module load netcdf/4.3.2-fasrc03

--- a/src/extra/env/gekko
+++ b/src/extra/env/gekko
@@ -1,0 +1,10 @@
+echo loadmodules for Isca on NTU Gekko
+
+export F90=mpiifort; echo $F90;
+export CC=mpiicc
+
+module purge
+module load intel/2018u3
+module load hdf/1.10.0
+module load netcdf-fortran/4.4.4
+module load netcdf/4.6.1


### PR DESCRIPTION
With some help from the respective IT personnel, I was able to build Isca on two different clusters:
* FASRC Cannon cluster (Harvard)
* EOS Gekko Cluster (NTU Singapore)

Below are the environment files!