### PR TITLE
Allow option to use default smoothing over land

### DIFF
--- a/src/atmos_spectral/init/spectral_init_cond.F90
+++ b/src/atmos_spectral/init/spectral_init_cond.F90
@@ -220,7 +220,7 @@ else if(trim(topography_option) == 'input') then
                      ' but '//trim('INPUT/'//topog_file_name)//' does not exist', FATAL)
    endif
    
-  if(smooth_input_land):
+  if(smooth_input_land) then
      ocean_mask = .true. ! If Broccoli smoothing is to be applied over 'input' land as well as ocean, set this as 'ocean' here
   else
      where(land_ones > 0.)

--- a/src/atmos_spectral/init/spectral_init_cond.F90
+++ b/src/atmos_spectral/init/spectral_init_cond.F90
@@ -70,8 +70,9 @@ character(len=64) :: topography_option = 'flat'  ! realistic topography computed
 character(len=64) :: topog_file_name  = 'topography.data.nc'
 character(len=64) :: topog_field_name = 'zsurf'
 character(len=256) :: land_field_name = 'land_mask'
+logical :: smooth_land = .false.
 
-namelist / spectral_init_cond_nml / initial_temperature, topography_option, topog_file_name, topog_field_name, land_field_name
+namelist / spectral_init_cond_nml / initial_temperature, topography_option, topog_file_name, topog_field_name, land_field_name, smooth_input_land
 
 contains
 
@@ -218,12 +219,16 @@ else if(trim(topography_option) == 'input') then
      call error_mesg('get_topography','topography_option="'//trim(topography_option)//'"'// &
                      ' but '//trim('INPUT/'//topog_file_name)//' does not exist', FATAL)
    endif
-    
-   where(land_ones > 0.)
-     ocean_mask = .false.
-   elsewhere
-     ocean_mask = .true.
-   end where
+   
+  if(smooth_input_land==.true.):
+     ocean_mask = .true. ! If Broccoli smoothing is to be applied over 'input' land as well as ocean, set this as 'ocean' here
+  else
+     where(land_ones > 0.)
+       ocean_mask = .false.
+     elsewhere
+       ocean_mask = .true.
+     end where
+  endif
 
    surf_geopotential = grav*surf_height
 

--- a/src/atmos_spectral/init/spectral_init_cond.F90
+++ b/src/atmos_spectral/init/spectral_init_cond.F90
@@ -220,7 +220,7 @@ else if(trim(topography_option) == 'input') then
                      ' but '//trim('INPUT/'//topog_file_name)//' does not exist', FATAL)
    endif
    
-  if(smooth_input_land==.true.):
+  if(smooth_input_land):
      ocean_mask = .true. ! If Broccoli smoothing is to be applied over 'input' land as well as ocean, set this as 'ocean' here
   else
      where(land_ones > 0.)

--- a/src/atmos_spectral/init/spectral_init_cond.F90
+++ b/src/atmos_spectral/init/spectral_init_cond.F90
@@ -70,7 +70,7 @@ character(len=64) :: topography_option = 'flat'  ! realistic topography computed
 character(len=64) :: topog_file_name  = 'topography.data.nc'
 character(len=64) :: topog_field_name = 'zsurf'
 character(len=256) :: land_field_name = 'land_mask'
-logical :: smooth_land = .false.
+logical :: smooth_input_land = .false.
 
 namelist / spectral_init_cond_nml / initial_temperature, topography_option, topog_file_name, topog_field_name, land_field_name, smooth_input_land
 


### PR DESCRIPTION
I added a namelist option to allow smoothing of Gibbs ripples over land. Currently this is only done over ocean to avoid trimming mountains. This option just tells the model to apply the same method over land too. This does slightly cut mountain tops, but significantly improves rippling and I have found it useful when using idealised topography. 
Default is off, trip tests are all clean. 