### PR TITLE
Fixed line length nml fix

### DIFF
--- a/src/extra/python/isca/experiment.py
+++ b/src/extra/python/isca/experiment.py
@@ -144,8 +144,11 @@ class Experiment(Logger, EventEmitter):
     def write_namelist(self, outdir):
         namelist_file = P(outdir, 'input.nml')
         self.log.info('Writing namelist to %r' % namelist_file)
-        #A fixed column width is added to be a fixed number as most string namelist variables are width 256 in Isca, so that width plus some indentation and the namelist parameters own name should not exceed 350 characters. Default f90nml value is 72, which is regularly too short for some namelist variables where directories are pointed to.
-        self.namelist.column_width=350
+        # A fixed column width is added to be a fixed number as most string namelist variables are
+        # width 256 in Isca, so that width plus some indentation and the namelist parameters own 
+        # name should not exceed 350 characters. Default f90nml value is 72, which is regularly 
+        # too short for some namelist variables where directories are pointed to.
+        self.namelist.column_width = 350
         self.namelist.write(namelist_file)
 
     def write_diag_table(self, outdir):

--- a/src/extra/python/isca/experiment.py
+++ b/src/extra/python/isca/experiment.py
@@ -144,6 +144,8 @@ class Experiment(Logger, EventEmitter):
     def write_namelist(self, outdir):
         namelist_file = P(outdir, 'input.nml')
         self.log.info('Writing namelist to %r' % namelist_file)
+        #A fixed column width is added to be a fixed number as most string namelist variables are width 256 in Isca, so that width plus some indentation and the namelist parameters own name should not exceed 350 characters. Default f90nml value is 72, which is regularly too short for some namelist variables where directories are pointed to.
+        self.namelist.column_width=350
         self.namelist.write(namelist_file)
 
     def write_diag_table(self, outdir):


### PR DESCRIPTION
The latest version of `f90nml` available on pip, v1.2, enforces fixed-column widths for string variables when writing out nml files. The default line width is 72 characters. The default is the same in previous versions of `f90nml`, but did not seem to be enforced. This has the effect of splitting some variables across multiple lines in `input.nml`, causing the model to fail when these are read. An example case is `socrates_rad_nml` with the `lw_spectral_filename` parameter pointing to a directory that is generally longer than 72 characters. I have modified the python front end to allow for a maximum width of 350. This is longer than the 256 characters this namelist parameter has as its own maximum, therefore leaving room for long variable names too.