### PR TITLE
Address the travis timeout issue: add travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   - if [[ "$CONDA_ENV" == "docs" ]]; then
       sphinx-build -n -b html -d docs/_build/doctrees docs/source docs/_build/html;
     else
-      pytest -v;
+      travis_wait 30 pytest -v;
     fi;
 
 after_success:


### PR DESCRIPTION
I prefixed the `pytest` command (which triggers the builds) with `travis_wait 30` (30 min). Partially addresses #182.