### PR TITLE
Frierson Test Case Fix (Issue 184)

### DIFF
--- a/src/shared/diag_manager/diag_table.F90
+++ b/src/shared/diag_manager/diag_table.F90
@@ -357,7 +357,7 @@ CONTAINS
     INTEGER, INTENT(out), OPTIONAL, TARGET :: istat
     CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg
 
-    INTEGER, PARAMETER :: DT_LINE_LENGTH = 256
+    INTEGER, PARAMETER :: DT_LINE_LENGTH = 512
 
     INTEGER :: stdlog_unit !< Fortran file unit number for the stdlog file.
     INTEGER :: record_len !< String length of the diag_table line read in.

--- a/src/shared/mpp/mpp.F90
+++ b/src/shared/mpp/mpp.F90
@@ -1182,7 +1182,7 @@ private
 !  variables needed for subroutine read_input_nml (include/mpp_util.inc)
 !
 ! parameter defining length of character variables 
-  integer, parameter :: INPUT_STR_LENGTH = 256
+  integer, parameter :: INPUT_STR_LENGTH = 512
 ! public variable needed for reading input.nml from an internal file
   character(len=INPUT_STR_LENGTH), dimension(:), allocatable, public :: input_nml_file
 !***********************************************************************


### PR DESCRIPTION
To fix the frierson test case issue, line lengths in diag_table.f90 a…nd mpp.f90 were changed from 256 to 512 where read_ascii_file is called. Other consequences unknown, this may only be a temporary fix.