### PR TITLE
Master copy vegetation

### DIFF
--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -199,7 +199,7 @@ character(len=*), parameter :: tagname = '$Name:  $'
 
 logical :: do_init = .true.
 
-!jp As grav is no longer a `parameter`, initialisation of these variables
+! As grav is no longer a `parameter`, initialisation of these variables
 !   now happens in surface_flux_init
 real :: d622, d378, hlars, gcp, kappa, d608
 
@@ -263,7 +263,7 @@ logical :: do_simple             = .false.
 
 real    :: land_humidity_prefactor  =  1.0    ! Default is that land makes no difference to evaporative fluxes
 real    :: land_evap_prefactor  =  1.0    ! Default is that land makes no difference to evaporative fluxes
-real    :: veg_evap_prefactor = 1.0 ! Default prefactor for vegetation - no difference to evaporative fluxes 
+real    :: veg_evap_prefactor = 1.0 ! Default prefactor for vegetation = 1. - no difference to evaporative fluxes. Setting veg_evap_prefactor to a value between 0 and <1 (e.g. 0.5) for a doubling of CO2 mimicks the effect of stomatal closure on land-surface evaporation. 
 
 real    :: flux_heat_gp  =  5.7    ! Default value for Jupiter of 5.7 Wm^-2
 real    :: diabatic_acce =  1.0    ! Diabatic acceleration??
@@ -349,7 +349,7 @@ subroutine surface_flux_1d (                                           &
      w_atm,     u_star,     b_star,     q_star,                        &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
-     potential_evap,                                                   & !mp586 add potential evaporation
+     potential_evap,                                                   & ! add potential evaporation, here defined as the evaporation that would occur if the bucket were full
      ex_del_m, ex_del_h, ex_del_q,                                     & !for 10m winds and 2m temp
      temp_2m, u_10m, v_10m, 				      	       & !for 10m winds and 2m temp
      q_2m, rh_2m,                                                      & !Add 2m q and RH
@@ -435,7 +435,7 @@ subroutine surface_flux_1d (                                           &
   ! initilaize surface air humidity according to surface type
   where (land)
 !     q_surf0 = q_surf ! land calculates it
-     q_surf0 = q_sat !s our simplified land evaporation model does not calculate q_surf, so we specify it as q_sat.
+     q_surf0 = q_sat ! our simplified land evaporation model does not calculate q_surf, so we specify it as q_sat.
   elsewhere
      q_surf0 = q_sat  ! everything else assumes saturated sfc humidity
   endwhere
@@ -600,10 +600,10 @@ subroutine surface_flux_1d (                                           &
 			elsewhere	
                 flux_q    =  veg_evap_prefactor * bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
 			end where
-			potential_evap = veg_evap_prefactor * rho_drag * (q_surf0 - q_atm) !mp586 added calculation of potential evaporation 
+			potential_evap = veg_evap_prefactor * rho_drag * (q_surf0 - q_atm) ! added calculation of potential evaporation 
 		elsewhere
 	        flux_q    =  rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
-	        potential_evap = flux_q !mp586 added calculation of potential evaporation
+	        potential_evap = flux_q ! added calculation of potential evaporation
 		end where
 		
 	    depth_change_lh_1d  = flux_q * dt/dens_h2o 
@@ -718,7 +718,7 @@ subroutine surface_flux_0d (                                                 &
      w_atm_0,     u_star_0,     b_star_0,     q_star_0,                      &
      dhdt_surf_0, dedt_surf_0,  dedq_surf_0,  drdt_surf_0,                   &
      dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0, dtaudv_atm_0,                  &
-     potential_evap_0,												   		 & !mp586 add potential evaporation
+     potential_evap_0,												   		 & ! add potential evaporation
      ex_del_m_0, ex_del_h_0, ex_del_q_0,                                     & ! for 10m winds and 2m temp
      temp_2m_0, u_10m_0, v_10m_0, 				      	     & ! for 10m winds and 2m temp
      q_2m_0, rh_2m_0,                                                        & !2m q and RH
@@ -736,7 +736,7 @@ subroutine surface_flux_0d (                                                 &
        dhdt_surf_0, dedt_surf_0,  dedq_surf_0, drdt_surf_0,            &
        dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0,dtaudv_atm_0,           &
        w_atm_0,     u_star_0,     b_star_0,    q_star_0,               &
-       potential_evap_0,												   & !mp586 add potential evaporation
+       potential_evap_0,												   & ! add potential evaporation
        cd_m_0,      cd_t_0,       cd_q_0,      			       &
        ex_del_m_0, ex_del_h_0, ex_del_q_0,                        	       & ! for 10m winds and 2m temp
        temp_2m_0, u_10m_0, v_10m_0,                                    & ! for 10m winds and 2m temp
@@ -758,7 +758,7 @@ subroutine surface_flux_0d (                                                 &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
-       potential_evap,										 & !mp586 add potential evaporation
+       potential_evap,										 & ! add potential evaporation
        cd_m,      cd_t,       cd_q,	 		     & 
        ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
@@ -806,7 +806,7 @@ subroutine surface_flux_0d (                                                 &
        w_atm,     u_star,     b_star,     q_star,                        &
        dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
        dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
-       potential_evap,												     & !mp586 add potential evaporation
+       potential_evap,												     & ! add potential evaporation
        ex_del_m, ex_del_h, ex_del_q,                                     & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                            & ! for 10m winds and 2m temp
        q_2m, rh_2m,                                                      & !Add 2m q and RH
@@ -857,7 +857,7 @@ subroutine surface_flux_2d (                                           &
      w_atm,     u_star,     b_star,     q_star,                        &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
-     potential_evap,												   & !mp586 add potential evaporation
+     potential_evap,												   & ! add potential evaporation
      ex_del_m, ex_del_h, ex_del_q,                                     & ! for 10m winds and 2m temp
      temp_2m, u_10m, v_10m,                                            & ! for 10m winds and 2m temp
      q_2m, rh_2m,                                                      & !Add 2m q and RH
@@ -875,7 +875,7 @@ subroutine surface_flux_2d (                                           &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
-       potential_evap,										 & !mp586 add potential evaporation
+       potential_evap,										 & ! add potential evaporation
        cd_m,      cd_t,       cd_q,                          &
        ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
@@ -883,9 +883,9 @@ subroutine surface_flux_2d (                                           &
 
   real, intent(inout), dimension(:,:) :: q_surf
   logical, intent(in) :: bucket ! Add bucket
-  real, intent(inout), dimension(:,:) :: bucket_depth ! RG Add bucket
-  real, intent(inout), dimension(:,:) :: depth_change_lh ! RG Add bucket
-  real, intent(in), dimension(:,:)    :: depth_change_conv, depth_change_cond ! RG Add bucket
+  real, intent(inout), dimension(:,:) :: bucket_depth !  Add bucket
+  real, intent(inout), dimension(:,:) :: depth_change_lh !  Add bucket
+  real, intent(in), dimension(:,:)    :: depth_change_conv, depth_change_cond !  Add bucket
   real, intent(in) :: max_bucket_depth_land  ! RG Add bucket
   real, intent(in) :: dt
 
@@ -905,7 +905,7 @@ subroutine surface_flux_2d (                                           &
           w_atm(:,j),     u_star(:,j),     b_star(:,j),     q_star(:,j),                                  &
           dhdt_surf(:,j), dedt_surf(:,j),  dedq_surf(:,j),  drdt_surf(:,j),                               &
           dhdt_atm(:,j),  dedq_atm(:,j),   dtaudu_atm(:,j), dtaudv_atm(:,j),                              &
-          potential_evap(:,j),												   							  & !mp586 add potential evaporation
+          potential_evap(:,j),												   							  & ! add potential evaporation
      	  ex_del_m(:,j), ex_del_h(:,j), ex_del_q(:,j),                                                    & ! for 10m winds and 2m temp
           temp_2m(:,j), u_10m(:,j), v_10m(:,j),                                                           & ! for 10m winds and 2m temp
           q_2m(:,j), rh_2m(:,j),                                                                          &

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -349,6 +349,7 @@ subroutine surface_flux_1d (                                           &
      w_atm,     u_star,     b_star,     q_star,                        &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
+     potential_evap,                                                   & !mp586 add potential evaporation
      ex_del_m, ex_del_h, ex_del_q,                                     & !for 10m winds and 2m temp
      temp_2m, u_10m, v_10m, 				      	       & !for 10m winds and 2m temp
      q_2m, rh_2m,                                                      & !Add 2m q and RH
@@ -369,11 +370,11 @@ subroutine surface_flux_1d (                                           &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
+       potential_evap,                                       & ! add potential evaporation
        cd_m,      cd_t,       cd_q,                          & 
        ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
        q_2m, rh_2m                                             ! Add 2m q and RH
-
 
   real, intent(inout), dimension(:) :: q_surf
   real, intent(inout), dimension(:) :: bucket_depth                              ! Add bucket
@@ -599,8 +600,10 @@ subroutine surface_flux_1d (                                           &
 			elsewhere	
                 flux_q    =  veg_evap_prefactor * bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
 			end where
+			potential_evap = veg_evap_prefactor * rho_drag * (q_surf0 - q_atm) !mp586 added calculation of potential evaporation 
 		elsewhere
 	        flux_q    =  rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
+	        potential_evap = flux_q !mp586 added calculation of potential evaporation
 		end where
 		
 	    depth_change_lh_1d  = flux_q * dt/dens_h2o 
@@ -715,6 +718,7 @@ subroutine surface_flux_0d (                                                 &
      w_atm_0,     u_star_0,     b_star_0,     q_star_0,                      &
      dhdt_surf_0, dedt_surf_0,  dedq_surf_0,  drdt_surf_0,                   &
      dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0, dtaudv_atm_0,                  &
+     potential_evap_0,												   		 & !mp586 add potential evaporation
      ex_del_m_0, ex_del_h_0, ex_del_q_0,                                     & ! for 10m winds and 2m temp
      temp_2m_0, u_10m_0, v_10m_0, 				      	     & ! for 10m winds and 2m temp
      q_2m_0, rh_2m_0,                                                        & !2m q and RH
@@ -732,10 +736,12 @@ subroutine surface_flux_0d (                                                 &
        dhdt_surf_0, dedt_surf_0,  dedq_surf_0, drdt_surf_0,            &
        dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0,dtaudv_atm_0,           &
        w_atm_0,     u_star_0,     b_star_0,    q_star_0,               &
+       potential_evap_0,												   & !mp586 add potential evaporation
        cd_m_0,      cd_t_0,       cd_q_0,      			       &
        ex_del_m_0, ex_del_h_0, ex_del_q_0,                        	       & ! for 10m winds and 2m temp
        temp_2m_0, u_10m_0, v_10m_0,                                    & ! for 10m winds and 2m temp
        q_2m_0, rh_2m_0
+
   real, intent(inout) :: q_surf_0
   real, intent(in)    :: dt
 
@@ -752,6 +758,7 @@ subroutine surface_flux_0d (                                                 &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
+       potential_evap,										 & !mp586 add potential evaporation
        cd_m,      cd_t,       cd_q,	 		     & 
        ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
@@ -784,6 +791,7 @@ subroutine surface_flux_0d (                                                 &
   q_surf(1)      = q_surf_0
   land(1)        = land_0
   seawater(1)    = seawater_0
+
   avail(1)       = avail_0
 
   call surface_flux_1d (                                                 &
@@ -798,6 +806,7 @@ subroutine surface_flux_0d (                                                 &
        w_atm,     u_star,     b_star,     q_star,                        &
        dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
        dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
+       potential_evap,												     & !mp586 add potential evaporation
        ex_del_m, ex_del_h, ex_del_q,                                     & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                            & ! for 10m winds and 2m temp
        q_2m, rh_2m,                                                      & !Add 2m q and RH
@@ -824,6 +833,7 @@ subroutine surface_flux_0d (                                                 &
   cd_m_0       = cd_m(1)
   cd_t_0       = cd_t(1)
   cd_q_0       = cd_q(1)
+  potential_evap_0 = potential_evap(1)
   ex_del_m_0   = ex_del_m(1)						! for 10m winds and 2m temp
   ex_del_h_0   = ex_del_h(1)						! for 10m winds and 2m temp
   ex_del_q_0   = ex_del_q(1)						! for 10m winds and 2m temp
@@ -847,6 +857,7 @@ subroutine surface_flux_2d (                                           &
      w_atm,     u_star,     b_star,     q_star,                        &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
+     potential_evap,												   & !mp586 add potential evaporation
      ex_del_m, ex_del_h, ex_del_q,                                     & ! for 10m winds and 2m temp
      temp_2m, u_10m, v_10m,                                            & ! for 10m winds and 2m temp
      q_2m, rh_2m,                                                      & !Add 2m q and RH
@@ -864,6 +875,7 @@ subroutine surface_flux_2d (                                           &
        dhdt_surf, dedt_surf,  dedq_surf, drdt_surf,          &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
+       potential_evap,										 & !mp586 add potential evaporation
        cd_m,      cd_t,       cd_q,                          &
        ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
        temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
@@ -893,6 +905,7 @@ subroutine surface_flux_2d (                                           &
           w_atm(:,j),     u_star(:,j),     b_star(:,j),     q_star(:,j),                                  &
           dhdt_surf(:,j), dedt_surf(:,j),  dedq_surf(:,j),  drdt_surf(:,j),                               &
           dhdt_atm(:,j),  dedq_atm(:,j),   dtaudu_atm(:,j), dtaudv_atm(:,j),                              &
+          potential_evap(:,j),												   							  & !mp586 add potential evaporation
      	  ex_del_m(:,j), ex_del_h(:,j), ex_del_q(:,j),                                                    & ! for 10m winds and 2m temp
           temp_2m(:,j), u_10m(:,j), v_10m(:,j),                                                           & ! for 10m winds and 2m temp
           q_2m(:,j), rh_2m(:,j),                                                                          &

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -261,12 +261,12 @@ logical :: ncar_ocean_flux_orig  = .false. ! for backwards compatibility
 logical :: raoult_sat_vap        = .false.
 logical :: do_simple             = .false.
 
-real    :: land_humidity_prefactor  =  1.0    !s Default is that land makes no difference to evaporative fluxes
-real    :: land_evap_prefactor  =  1.0    !s Default is that land makes no difference to evaporative fluxes
-real    :: veg_evap_prefactor = 1.0 !mp586 Default prefactor for vegetation - no difference to evaporative fluxes 
+real    :: land_humidity_prefactor  =  1.0    ! Default is that land makes no difference to evaporative fluxes
+real    :: land_evap_prefactor  =  1.0    ! Default is that land makes no difference to evaporative fluxes
+real    :: veg_evap_prefactor = 1.0 ! Default prefactor for vegetation - no difference to evaporative fluxes 
 
-real    :: flux_heat_gp  =  5.7    !s Default value for Jupiter of 5.7 Wm^-2
-real    :: diabatic_acce =  1.0    !s Diabatic acceleration??
+real    :: flux_heat_gp  =  5.7    ! Default value for Jupiter of 5.7 Wm^-2
+real    :: diabatic_acce =  1.0    ! Diabatic acceleration??
 
 
 namelist /surface_flux_nml/ no_neg_q,             &
@@ -280,10 +280,10 @@ namelist /surface_flux_nml/ no_neg_q,             &
                             ncar_ocean_flux_orig, &
                             raoult_sat_vap,       &
                             do_simple,            &
-                            land_humidity_prefactor, & !s Added to make land 'dry', i.e. to decrease the evaporative heat flux in areas of land.
-                            land_evap_prefactor, & !s Added to make land 'dry', i.e. to decrease the evaporative heat flux in areas of land.
-                            veg_evap_prefactor, &!mp586 Added to allow for plant physiological response to CO2 forcing 
-                            flux_heat_gp,         &    !s prescribed lower boundary heat flux on a giant planet
+                            land_humidity_prefactor, & ! Added to make land 'dry', i.e. to decrease the evaporative heat flux in areas of land.
+                            land_evap_prefactor, & ! Added to make land 'dry', i.e. to decrease the evaporative heat flux in areas of land.
+                            veg_evap_prefactor, &! Added to allow for plant physiological response to CO2 forcing 
+                            flux_heat_gp,         &    ! prescribed lower boundary heat flux on a giant planet
 			    diabatic_acce
 
 
@@ -340,8 +340,8 @@ contains
 subroutine surface_flux_1d (                                           &
      t_atm,     q_atm_in,   u_atm,     v_atm,     p_atm,     z_atm,    &
      p_surf,    t_surf,     t_ca,      q_surf,                         &
-	 bucket, bucket_depth, max_bucket_depth_land,                      & !RG Add bucket
-     depth_change_lh_1d, depth_change_conv_1d, depth_change_cond_1d,   & !RG Add bucket
+	 bucket, bucket_depth, max_bucket_depth_land,                      & ! Add bucket
+     depth_change_lh_1d, depth_change_conv_1d, depth_change_cond_1d,   & ! Add bucket
      u_surf,    v_surf,                                                &
      rough_mom, rough_heat, rough_moist, rough_scale, gust,            &
      flux_t, flux_q, flux_r, flux_u, flux_v,                           &
@@ -349,8 +349,8 @@ subroutine surface_flux_1d (                                           &
      w_atm,     u_star,     b_star,     q_star,                        &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
-     ex_del_m, ex_del_h, ex_del_q,                                     & !mp586 for 10m winds and 2m temp
-     temp_2m, u_10m, v_10m, 				      	       & !mp586 for 10m winds and 2m temp
+     ex_del_m, ex_del_h, ex_del_q,                                     & !for 10m winds and 2m temp
+     temp_2m, u_10m, v_10m, 				      	       & !for 10m winds and 2m temp
      q_2m, rh_2m,                                                      & !Add 2m q and RH
      dt,        land,      seawater,     avail  )
 !</PUBLICROUTINE>
@@ -358,7 +358,7 @@ subroutine surface_flux_1d (                                           &
 ! ============================================================================
   ! ---- arguments -----------------------------------------------------------
   logical, intent(in), dimension(:) :: land,  seawater, avail
-  logical, intent(in) :: bucket         !RG Add bucket
+  logical, intent(in) :: bucket         ! Add bucket
   real, intent(in),  dimension(:) :: &
        t_atm,     q_atm_in,   u_atm,     v_atm,              &
        p_atm,     z_atm,      t_ca,                          &
@@ -370,22 +370,22 @@ subroutine surface_flux_1d (                                           &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
        cd_m,      cd_t,       cd_q,                          & 
-       ex_del_m, ex_del_h, ex_del_q,                         & !mp586 for 10m winds and 2m temp
-       temp_2m, u_10m, v_10m,                                & !mp586 for 10m winds and 2m temp
+       ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
+       temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
        q_2m, rh_2m                                             ! Add 2m q and RH
 
 
   real, intent(inout), dimension(:) :: q_surf
-  real, intent(inout), dimension(:) :: bucket_depth                              !RG Add bucket
-  real, intent(inout), dimension(:) :: depth_change_lh_1d                        !RG Add bucket
-  real, intent(in), dimension(:) :: depth_change_conv_1d, depth_change_cond_1d   !RG Add bucket
+  real, intent(inout), dimension(:) :: bucket_depth                              ! Add bucket
+  real, intent(inout), dimension(:) :: depth_change_lh_1d                        ! Add bucket
+  real, intent(in), dimension(:) :: depth_change_conv_1d, depth_change_cond_1d   ! Add bucket
   real, intent(in) :: max_bucket_depth_land
   real, intent(in) :: dt
 
   ! ---- local constants -----------------------------------------------------
   ! temperature increment and its reciprocal value for comp. of derivatives
   real, parameter:: del_temp=0.1, del_temp_inv=1.0/del_temp
-  real:: zrefm, zrefh                                          !mp586 for 10m winds and 2m temp
+  real:: zrefm, zrefh                                          ! for 10m winds and 2m temp
 
 
   ! ---- local vars ----------------------------------------------------------
@@ -508,7 +508,7 @@ subroutine surface_flux_1d (                                           &
        cd_m, cd_t, cd_q, u_star, b_star, avail             )
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!!!!!! added by mp586 for 10m winds and 2m temperature add mo_profile()!!!!!!!!
+!!!!!!! added for 10m winds and 2m temperature add mo_profile()!!!!!!!!
 
 
   zrefm = 10. !want winds at 10m
@@ -535,7 +535,7 @@ subroutine surface_flux_1d (                                           &
        where (avail) &
            v_10m = v_atm * ex_del_m ! setting v at surface to 0.
 
-!!!!!!!!!!!! end of mp586 additions !!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!! end of 10m wind and 2m temperature additions !!!!!!!!!!!!!!!!!!!!!!!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       ! Add 2m q and RH
@@ -588,14 +588,14 @@ subroutine surface_flux_1d (                                           &
      rho_drag  =  drag_q * rho
   end where  
 
-!RG Add bucket - if bucket is on evaluate fluxes based on moisture availability.
-!RG Note changes to avail statements to allow bucket to be switched on or off	  
+! Add bucket - if bucket is on evaluate fluxes based on moisture availability.
+! Note changes to avail statements to allow bucket to be switched on or off	  
   if (bucket) then
 	  where (avail)
 	      ! begin LJJ addition
   		where(land)
 			where (bucket_depth >= max_bucket_depth_land*0.75)
-				flux_q    =  veg_evap_prefactor * rho_drag * (q_surf0 - q_atm) !mp586 added vegetation response to co2
+				flux_q    =  veg_evap_prefactor * rho_drag * (q_surf0 - q_atm) ! added vegetation response to co2
 			elsewhere	
                 flux_q    =  veg_evap_prefactor * bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
 			end where
@@ -605,7 +605,7 @@ subroutine surface_flux_1d (                                           &
 		
 	    depth_change_lh_1d  = flux_q * dt/dens_h2o 
 	    where (flux_q > 0.0 .and. bucket_depth < depth_change_lh_1d) ! where more evaporation than what's in bucket, empty bucket
-	        flux_q = veg_evap_prefactor * bucket_depth * dens_h2o / dt !mp586 added veg response to co2 forcing 
+	        flux_q = veg_evap_prefactor * bucket_depth * dens_h2o / dt ! added veg response to co2 forcing 
 	        depth_change_lh_1d = flux_q * dt / dens_h2o
 	    end where 
     
@@ -618,9 +618,9 @@ subroutine surface_flux_1d (                                           &
 	      dedq_atm = -rho_drag ! d(latent heat flux)/d(atmospheric mixing ratio)
 		  where(land)
 			  where (bucket_depth >= max_bucket_depth_land*0.75)
-				  dedt_surf =  veg_evap_prefactor * rho_drag * (q_sat1 - q_sat) *del_temp_inv !mp586 added vegetation response to co2 
+				  dedt_surf =  veg_evap_prefactor * rho_drag * (q_sat1 - q_sat) *del_temp_inv ! added vegetation response to co2 
 			  elsewhere
-      	          dedt_surf =  veg_evap_prefactor * bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_sat1 - q_sat) *del_temp_inv !mp586 added veg response
+      	          dedt_surf =  veg_evap_prefactor * bucket_depth/(max_bucket_depth_land*0.75) * rho_drag * (q_sat1 - q_sat) *del_temp_inv ! added veg response
 			  end where
 		  elsewhere
  	          dedt_surf =  rho_drag * (q_sat1 - q_sat) *del_temp_inv 
@@ -630,10 +630,10 @@ subroutine surface_flux_1d (                                           &
 	  end where    
   else
 
-!RG otherwise revert to simple land model
+! otherwise revert to simple land model
   where (avail)
      where (land)
-!s      Simplified land model uses simple prefactor in front of qsurf0. Land is therefore basically the same as sea, but with this prefactor, hence the changes to dedq_surf and dedt_surf also.
+!      Simplified land model uses simple prefactor in front of qsurf0. Land is therefore basically the same as sea, but with this prefactor, hence the changes to dedq_surf and dedt_surf also.
         flux_q    =  rho_drag * land_evap_prefactor * (land_humidity_prefactor*q_surf0 - q_atm) ! flux of water vapor  (Kg/(m**2 s))
         dedq_surf = 0
         dedt_surf =  rho_drag * land_evap_prefactor * (land_humidity_prefactor*q_sat1 - q_sat) *del_temp_inv
@@ -648,7 +648,7 @@ subroutine surface_flux_1d (                                           &
    end where
   endif
 
-!RG end Add bucket changes
+! end Add bucket changes
 
   where (avail)
 
@@ -715,8 +715,8 @@ subroutine surface_flux_0d (                                                 &
      w_atm_0,     u_star_0,     b_star_0,     q_star_0,                      &
      dhdt_surf_0, dedt_surf_0,  dedq_surf_0,  drdt_surf_0,                   &
      dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0, dtaudv_atm_0,                  &
-     ex_del_m_0, ex_del_h_0, ex_del_q_0,                                     & !mp586 for 10m winds and 2m temp
-     temp_2m_0, u_10m_0, v_10m_0, 				      	     & !mp586 for 10m winds and 2m temp
+     ex_del_m_0, ex_del_h_0, ex_del_q_0,                                     & ! for 10m winds and 2m temp
+     temp_2m_0, u_10m_0, v_10m_0, 				      	     & ! for 10m winds and 2m temp
      q_2m_0, rh_2m_0,                                                        & !2m q and RH
      dt,          land_0,       seawater_0,  avail_0  )
 
@@ -733,8 +733,8 @@ subroutine surface_flux_0d (                                                 &
        dhdt_atm_0,  dedq_atm_0,   dtaudu_atm_0,dtaudv_atm_0,           &
        w_atm_0,     u_star_0,     b_star_0,    q_star_0,               &
        cd_m_0,      cd_t_0,       cd_q_0,      			       &
-       ex_del_m_0, ex_del_h_0, ex_del_q_0,                        	       & !mp586 for 10m winds and 2m temp
-       temp_2m_0, u_10m_0, v_10m_0,                                    & !mp586 for 10m winds and 2m temp
+       ex_del_m_0, ex_del_h_0, ex_del_q_0,                        	       & ! for 10m winds and 2m temp
+       temp_2m_0, u_10m_0, v_10m_0,                                    & ! for 10m winds and 2m temp
        q_2m_0, rh_2m_0
   real, intent(inout) :: q_surf_0
   real, intent(in)    :: dt
@@ -753,15 +753,15 @@ subroutine surface_flux_0d (                                                 &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
        cd_m,      cd_t,       cd_q,	 		     & 
-       ex_del_m, ex_del_h, ex_del_q,                         & !mp586 for 10m winds and 2m temp
-       temp_2m, u_10m, v_10m,                                & !mp586 for 10m winds and 2m temp
+       ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
+       temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
        q_2m, rh_2m                                             !Add 2m q and RH
 
   real, dimension(1) :: q_surf
-  real, dimension(1) :: bucket_depth                                 !RG Add bucket 
-  real, dimension(1) :: depth_change_lh_1d                           !RG Add bucket
-  real, dimension(1) :: depth_change_conv_1d, depth_change_cond_1d   !RG Add bucket
-  real :: max_bucket_depth_land  !RG Add bucket
+  real, dimension(1) :: bucket_depth                                 ! Add bucket 
+  real, dimension(1) :: depth_change_lh_1d                           ! Add bucket
+  real, dimension(1) :: depth_change_conv_1d, depth_change_cond_1d   ! Add bucket
+  real :: max_bucket_depth_land  ! Add bucket
 
   avail = .true.
 
@@ -789,8 +789,8 @@ subroutine surface_flux_0d (                                                 &
   call surface_flux_1d (                                                 &
        t_atm,     q_atm,      u_atm,     v_atm,     p_atm,     z_atm,    &
        p_surf,    t_surf,     t_ca,      q_surf,                         &
-	   bucket, bucket_depth, max_bucket_depth_land,                      & !RG Add bucket
-       depth_change_lh_1d, depth_change_conv_1d, depth_change_cond_1d,   & !RG Add bucket
+	   bucket, bucket_depth, max_bucket_depth_land,                      & ! Add bucket
+       depth_change_lh_1d, depth_change_conv_1d, depth_change_cond_1d,   & ! Add bucket
        u_surf,    v_surf,                                                &
        rough_mom, rough_heat, rough_moist, rough_scale, gust,            &
        flux_t, flux_q, flux_r, flux_u, flux_v,                           &
@@ -798,8 +798,8 @@ subroutine surface_flux_0d (                                                 &
        w_atm,     u_star,     b_star,     q_star,                        &
        dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
        dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
-       ex_del_m, ex_del_h, ex_del_q,                                     & !mp586 for 10m winds and 2m temp
-       temp_2m, u_10m, v_10m,                                            & !mp586 for 10m winds and 2m temp
+       ex_del_m, ex_del_h, ex_del_q,                                     & ! for 10m winds and 2m temp
+       temp_2m, u_10m, v_10m,                                            & ! for 10m winds and 2m temp
        q_2m, rh_2m,                                                      & !Add 2m q and RH
        dt,        land,      seawater, avail  )
 
@@ -824,12 +824,12 @@ subroutine surface_flux_0d (                                                 &
   cd_m_0       = cd_m(1)
   cd_t_0       = cd_t(1)
   cd_q_0       = cd_q(1)
-  ex_del_m_0   = ex_del_m(1)						!mp586 for 10m winds and 2m temp
-  ex_del_h_0   = ex_del_h(1)						!mp586 for 10m winds and 2m temp
-  ex_del_q_0   = ex_del_q(1)						!mp586 for 10m winds and 2m temp
-  temp_2m_0    = temp_2m(1)						!mp586 for 10m winds and 2m temp
-  u_10m_0      = u_10m(1)						!mp586 for 10m winds and 2m temp
-  v_10m_0      = v_10m(1)						!mp586 for 10m winds and 2m temp
+  ex_del_m_0   = ex_del_m(1)						! for 10m winds and 2m temp
+  ex_del_h_0   = ex_del_h(1)						! for 10m winds and 2m temp
+  ex_del_q_0   = ex_del_q(1)						! for 10m winds and 2m temp
+  temp_2m_0    = temp_2m(1)						! for 10m winds and 2m temp
+  u_10m_0      = u_10m(1)						! for 10m winds and 2m temp
+  v_10m_0      = v_10m(1)						! for 10m winds and 2m temp
   q_2m_0       = q_2m(1)        !Add 2m q
   rh_2m_0      = rh_2m(1)       !Add 2m RH
 
@@ -838,8 +838,8 @@ end subroutine surface_flux_0d
 subroutine surface_flux_2d (                                           &
      t_atm,     q_atm_in,   u_atm,     v_atm,     p_atm,     z_atm,    &
      p_surf,    t_surf,     t_ca,      q_surf,                         &
-	 bucket, bucket_depth, max_bucket_depth_land,                      & !RG Add bucket
-     depth_change_lh,   depth_change_conv,   depth_change_cond,        & !RG Add bucket
+	 bucket, bucket_depth, max_bucket_depth_land,                      & ! Add bucket
+     depth_change_lh,   depth_change_conv,   depth_change_cond,        & ! Add bucket
      u_surf,    v_surf,                                                &
      rough_mom, rough_heat, rough_moist, rough_scale, gust,            &
      flux_t,    flux_q,     flux_r,    flux_u,    flux_v,              &
@@ -847,8 +847,8 @@ subroutine surface_flux_2d (                                           &
      w_atm,     u_star,     b_star,     q_star,                        &
      dhdt_surf, dedt_surf,  dedq_surf,  drdt_surf,                     &
      dhdt_atm,  dedq_atm,   dtaudu_atm, dtaudv_atm,                    &
-     ex_del_m, ex_del_h, ex_del_q,                                     & !mp586 for 10m winds and 2m temp
-     temp_2m, u_10m, v_10m,                                            & !mp586 for 10m winds and 2m temp
+     ex_del_m, ex_del_h, ex_del_q,                                     & ! for 10m winds and 2m temp
+     temp_2m, u_10m, v_10m,                                            & ! for 10m winds and 2m temp
      q_2m, rh_2m,                                                      & !Add 2m q and RH
      dt,        land,       seawater,  avail  )
 
@@ -865,12 +865,12 @@ subroutine surface_flux_2d (                                           &
        dhdt_atm,  dedq_atm,   dtaudu_atm,dtaudv_atm,         &
        w_atm,     u_star,     b_star,    q_star,             &
        cd_m,      cd_t,       cd_q,                          &
-       ex_del_m, ex_del_h, ex_del_q,                         & !mp586 for 10m winds and 2m temp
-       temp_2m, u_10m, v_10m,                                & !mp586 for 10m winds and 2m temp
+       ex_del_m, ex_del_h, ex_del_q,                         & ! for 10m winds and 2m temp
+       temp_2m, u_10m, v_10m,                                & ! for 10m winds and 2m temp
        q_2m, rh_2m                                             !Add 2m q and RH
 
   real, intent(inout), dimension(:,:) :: q_surf
-  logical, intent(in) :: bucket !RG Add bucket
+  logical, intent(in) :: bucket ! Add bucket
   real, intent(inout), dimension(:,:) :: bucket_depth ! RG Add bucket
   real, intent(inout), dimension(:,:) :: depth_change_lh ! RG Add bucket
   real, intent(in), dimension(:,:)    :: depth_change_conv, depth_change_cond ! RG Add bucket
@@ -884,8 +884,8 @@ subroutine surface_flux_2d (                                           &
      call surface_flux_1d (                                           &
           t_atm(:,j),     q_atm_in(:,j),   u_atm(:,j),     v_atm(:,j),     p_atm(:,j),     z_atm(:,j),    &
           p_surf(:,j),    t_surf(:,j),     t_ca(:,j),      q_surf(:,j),                                   &
-		  bucket, bucket_depth(:,j), max_bucket_depth_land,                                               & !RG Add bucket
-          depth_change_lh(:,j), depth_change_conv(:,j), depth_change_cond(:,j),                           & !RG Add bucket
+		  bucket, bucket_depth(:,j), max_bucket_depth_land,                                               & ! Add bucket
+          depth_change_lh(:,j), depth_change_conv(:,j), depth_change_cond(:,j),                           & ! Add bucket
           u_surf(:,j),    v_surf(:,j),                                                                    &
           rough_mom(:,j), rough_heat(:,j), rough_moist(:,j), rough_scale(:,j), gust(:,j),                 &
           flux_t(:,j),    flux_q(:,j),     flux_r(:,j),    flux_u(:,j),    flux_v(:,j),                   &
@@ -893,8 +893,8 @@ subroutine surface_flux_2d (                                           &
           w_atm(:,j),     u_star(:,j),     b_star(:,j),     q_star(:,j),                                  &
           dhdt_surf(:,j), dedt_surf(:,j),  dedq_surf(:,j),  drdt_surf(:,j),                               &
           dhdt_atm(:,j),  dedq_atm(:,j),   dtaudu_atm(:,j), dtaudv_atm(:,j),                              &
-     	  ex_del_m(:,j), ex_del_h(:,j), ex_del_q(:,j),                                                    & !mp586 for 10m winds and 2m temp
-          temp_2m(:,j), u_10m(:,j), v_10m(:,j),                                                           & !mp586 for 10m winds and 2m temp
+     	  ex_del_m(:,j), ex_del_h(:,j), ex_del_q(:,j),                                                    & ! for 10m winds and 2m temp
+          temp_2m(:,j), u_10m(:,j), v_10m(:,j),                                                           & ! for 10m winds and 2m temp
           q_2m(:,j), rh_2m(:,j),                                                                          &
           dt,             land(:,j),       seawater(:,j),  avail(:,j)  )
   end do


### PR DESCRIPTION
**Simple vegetation model** 

1. Small additions to the bucket model to allow the user to set a ``vegetation pre-factor'' between 0. and 1. (where 1. is the original bucket model), to mimick stomatal closure with higher CO2 levels. 0 means no evaporation from the land surface. 

The namelist option for setting the veg_evap_prefactor to e.g. 0.5 is : 

    'surface_flux_nml': {
        'veg_evap_prefactor': 0.5 }

2. I've added the option to output ''potential evapotranspiration'' (see e.g. Budyko, 1974 or Milly and Dunne, 2016), defined here as the evaporation that would occur if the bucket were full. 

 `diag.add_field('atmosphere', 'potential_evap', time_avg=True)`

3. I did some code-cleanup in surface_flux.F90 and idealized_moist_phys.F90, getting rid of the author initials in the comments 

Budyko, M. I. (1974). Climate and Life. Academic Press, New York and London. English ed. edited by David H. Miller. ISBN 0-12-139450-6.
Milly, P. C. D. and Dunne, K. A. (2016). Potential evapotranspiration and continen- tal drying. Nature Climate Change, 6:946 – 949. doi: 10.1038/nclimate3046.


The trip tests (excluding the socrates-related ones) passed fine for those changes

Results for all of the test cases ran comparing 9cfd43e and 74f12d0 are as follows...
axisymmetric, : pass
bucket_model, : pass
frierson, : pass
giant_planet, : pass
held_suarez, : pass
MiMA, : pass
realistic_continents_fixed_sst, : pass
realistic_continents_variable_qflux, : pass
top_down_test, : pass
variable_co2_grey, : pass
variable_co2_rrtm : pass
Congratulations, all tests have passed