### PR TITLE
Giant Planet Test Case "Bug" fix

### DIFF
--- a/exp/test_cases/giant_planet/giant_planet_test_case.py
+++ b/exp/test_cases/giant_planet/giant_planet_test_case.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from isca import IscaCodeBase, DiagTable, Experiment, Namelist, GFDL_BASE
 
-NCORES = 4
+NCORES = 8
 
 # a CodeBase can be a directory on the computer,
 # useful for iterative development
@@ -140,7 +140,7 @@ exp.namelist = namelist = Namelist({
     },
 
     'fms_nml': {
-        'domains_stack_size': 620000 #Setting size of stack available to model, which needs to be higher than the default when running at high spatial resolution
+        'domains_stack_size': 6200000 #Setting size of stack available to model, this can be decreased when not running at a high resolution. 
     },
 
     'fms_io_nml': {


### PR DESCRIPTION
As agreed with ST, after problems spotted by DW, the giant planet tes…t case crashes due to a memory problem. This crash happens on GV5 and ISCA HPC, therefore we assume it happens on most machines. It does not happen on the trip tests because this test case is set to a lower resolution for these. To ensure the test case works out of the box, we increase the stack size (and number of cores, as it was very slow). The original version did say in the fms namelist that the stack size should be increased for high res runs, but there is no error pointing to this.