### PR TITLE
Constants Docs (for future constants.f90)

### DIFF
--- a/docs/source/modules/constants.rst
+++ b/docs/source/modules/constants.rst
@@ -1,0 +1,86 @@
+
+Constants: Atmospheric and Planetary Parameters 
+===============================================
+
+Summary
+-------
+
+``constants.F90`` provides a number of controls that set the fundamental parameters of the planet being studied - it is used by nearly every other module in Isca. By default, Isca models a planet equivalent to earth in terms of physical characteristics such as size, surface gravity and rotational period. In addition, water is set as the default condensate for any moist physics modules that may be used.
+
+Planetary Parameters
+^^^^^^^^^^^^^^^^^^^^
+
+Below are a set of controls that allow the physical size and rotation to be set. This allows us to model a range of planets, including others in the Solar System such as Mars and Jupiter, in addition to exoplanets. Rotation can be set by two different parameters: a rotation rate :math:`\Omega` can be specified; or alternatively a period in seconds can be given that is converted back to a value of :math:`\Omega`.
+
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+| Name              | Default                          | Units                                 | Description                                     |
++===================+==================================+=======================================+=================================================+
+|``radius``         | 6371e3                           | m                                     | Radius of planet                                |
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+|``gravity``        | 9.80                             | ms :math:`^{-2}`                      | Surface gravitational acceleration              |
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+|``omega``          | 7.2921150e-5                     | rad :math:`\cdot` s :math:`^{-1}`     | Rotation rate of planet                         |
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+|``rotation_period``| -1.0 (inactive)                  | s                                     | Rotation period of planet (overrides ``omega`` )|
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+|``orbital_period`` | 31557600                         | s                                     | Orbital period of planet                        |
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+|``orbital_rate``   | :math:`2\pi` / ``orbital_period``|  rad :math:`\cdot` s :math:`^{-1}`    | Orbital rate of planet                          |
++-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
+
+.. note:: Whilst the rotation and orbital rates are set within this module, other parameters associated with planetary motion such as axial tilt (obliquity) and eccentricity are controlled from the ``astronomy_mod`` module.
+
+Dry Atmosphere
+^^^^^^^^^^^^^^
+
+Changing the dry atmosphere values allows atmospheres with a wide range of compositions to be studied, including both terrestrial planets (e.g. Earth) and gas giants such as Jupiter. In the case of Earth, the reference surface pressure is taken to be the mean sea level pressure.
+
+The dry air gas constant for any homogeneous atmosphere can be calculated from its chemical composition. It is calculated by dividing the universal gas constant :math:`R` by the average molar mass of the atmosphere.
+
++------------+----------------------+-------------------------------------+-------------------------------------------------------+
+| Name       | Default              | Units                               | Description                                           |
++============+======================+=====================================+=======================================================+
+|``pstd_mks``| 101325.0             | Pa / Nm :math:`^{-2}`               | Mean (reference) surface pressure (SI)                |
++------------+----------------------+-------------------------------------+-------------------------------------------------------+
+|``pstd``    | 1.013250e06          | dyn :math:`\cdot` cm :math:`^{-2}`  | Mean (reference) surface pressure (cgs)               |
++------------+----------------------+-------------------------------------+-------------------------------------------------------+
+|``rdgas``   | 287.04               | Jkg :math:`^{-1}`K :math:`^{-1}`    | Dry air gas constant                                  |
++------------+----------------------+-------------------------------------+-------------------------------------------------------+
+|``kappa``   | 2/7                  | dimensionless                       | Heat capacity ratio ( :math:`\gamma` for an ideal gas)|
++------------+----------------------+-------------------------------------+-------------------------------------------------------+
+|``cp_air``  | ``rvgas`` / ``kappa``| Jkg :math:`^{-1}`K :math:`^{-1}`    | Dry air heat capcity                                  |
++------------+----------------------+-------------------------------------+-------------------------------------------------------+
+
+.. note:: If the mean surface pressure value is changed here, it is necessary to also set ``reference_sea_level_press`` from the ``spectral_dynamics_nml`` namelist, else the output file will not extend to the pressure specified.
+
+
+Moist Atmosphere
+^^^^^^^^^^^^^^^^
+
+With the addition of moist physics, a number of additional namelist parameters can be used to change the primary condensate present in the atmosphere. This allows atmospheres in temperature regimes significantly different from Earth to be modelled, including Titan, which has an active methane cycle.
+
++--------------+-------------------+----------------------------------+-------------------------------------------+
+| Name         | Default           | Units                            | Description                               |
++==============+===================+==================================+===========================================+
+|``rvgas``     | 461.50            | Jkg :math:`^{-1}`K :math:`^{-1}` | Vapour gas constant                       |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``cp_vapor``  | 4 * ``rvgas``     | Jkg :math:`^{-1}`K :math:`^{-1}` | Vapour heat capacity                      |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``dens_vapor``| 1000              | kgm :math:`^{-3}`                | Density of condensate in the liquid phase |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``hlv``       | 2.500e6           | Jkg :math:`^{-1}`                | Latent heat of vapourisation of condensate|
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``hlf``       | 3.34e5            | Jkg :math:`^{-1}`                | Latent heat of fusion of condensate       |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``hls``       | ``hlv`` + ``hlf`` | Jkg :math:`^{-1}`                | Latent heat of sublimation of condensate  |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``tfreeze``   | 273.16            | K                                | Freezing point of condensate              |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+|``tppress``   | 610.78            | Pa / Nm :math:`^{-2}`            | Triple point pressure of condensate       |
++--------------+-------------------+----------------------------------+-------------------------------------------+
+
+
+
+Authors
+-------
+This documentation was written by Daniel Williams, peer reviewed by YY, and quality controlled by ZZ.

--- a/docs/source/modules/constants.rst
+++ b/docs/source/modules/constants.rst
@@ -5,30 +5,42 @@ Constants: Atmospheric and Planetary Parameters
 Summary
 -------
 
-``constants.F90`` provides a number of controls that set the fundamental parameters of the planet being studied - it is used by nearly every other module in Isca. By default, Isca models a planet equivalent to earth in terms of physical characteristics such as size, surface gravity and rotational period. In addition, water is set as the default condensate for any moist physics modules that may be used.
+``constants.F90`` provides a number of controls that set the fundamental parameters of the planet being studied - it is used by nearly every other module in Isca. By default, Isca models a planet equivalent to Earth in terms of physical characteristics such as size, surface gravity and rotational period. In addition, water is set as the default condensate for any moist physics modules that may be used.
 
 Planetary Parameters
 ^^^^^^^^^^^^^^^^^^^^
 
-Below are a set of controls that allow the physical size and rotation to be set. This allows us to model a range of planets, including others in the Solar System such as Mars and Jupiter, in addition to exoplanets. Rotation can be set by two different parameters: a rotation rate :math:`\Omega` can be specified; or alternatively a period in seconds can be given that is converted back to a value of :math:`\Omega`.
+Below are a set of controls that allow the physical size and rotation of a planet to be set in the namelist. This allows us to model a range of planets, including others in the Solar System such as Mars and Jupiter, in addition to exoplanets. Rotation can be set by two different parameters: a rotation rate ``omega`` can be specified; or alternatively a period in seconds can be given that is converted back to a value of ``omega``. 
 
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
-| Name              | Default                          | Units                                 | Description                                     |
-+===================+==================================+=======================================+=================================================+
-|``radius``         | 6371e3                           | m                                     | Radius of planet                                |
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
-|``gravity``        | 9.80                             | ms :math:`^{-2}`                      | Surface gravitational acceleration              |
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
-|``omega``          | 7.2921150e-5                     | rad :math:`\cdot` s :math:`^{-1}`     | Rotation rate of planet                         |
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
-|``rotation_period``| -1.0 (inactive)                  | s                                     | Rotation period of planet (overrides ``omega`` )|
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
-|``orbital_period`` | 31557600                         | s                                     | Orbital period of planet                        |
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
-|``orbital_rate``   | :math:`2\pi` / ``orbital_period``|  rad :math:`\cdot` s :math:`^{-1}`    | Orbital rate of planet                          |
-+-------------------+----------------------------------+---------------------------------------+-------------------------------------------------+
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+| Name                | Default                          | Units                            | Description                                               |
++=====================+==================================+==================================+===========================================================+
+|``radius``           | :math:`6371\times 10^3`          | m                                | Radius of planet                                          |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``gravity``          | :math:`9.80`                     | ms :math:`^{-2}`                 | Surface gravitational acceleration                        |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``omega``            | :math:`7.2921150\times 10^{-5}`  | rad :math:`\cdot` s :math:`^{-1}`| Rotation rate of planet                                   |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``rotation_period``  | :math:`-1.0` (inactive)          | s                                | Rotation period of planet (overrides ``omega`` )          |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``orbital_period``   | :math:`31557600`                 | s                                | Orbital period of planet                                  |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``orbital_rate``     | :math:`2\pi` / ``orbital_period``| rad :math:`\cdot` s :math:`^{-1}`| Orbital rate of planet                                    |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``solar_constant``   | :math:`1368.22`                  | Wm :math:`^{-2}`                 | Stellar irradiance                                        |
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
+|``earthday_multiple``| False                            | n/a                              | Modifies seconds per sol calculation (planetary solar day)|
++---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
 
-.. note:: Whilst the rotation and orbital rates are set within this module, other parameters associated with planetary motion such as axial tilt (obliquity) and eccentricity are controlled from the ``astronomy_mod`` module.
+By default the parameter ``seconds_per_sol`` (where ``earthday_multiple`` is false) is calculated using
+
+.. math:: \texttt{seconds_per_sol} = \left|\frac{2\pi}{\texttt{orbital_rate} - \texttt{omega}}\right| ,
+
+whereas setting ``earthday_multiple`` to true modifies the calculation to
+
+.. math:: \texttt{seconds_per_sol} = 86400 \cdot \frac{\texttt{earth_omega}}{\texttt{omega}} .
+
+.. note:: Whilst the rotation and orbital rates are set within this module, other parameters associated with planetary motion such as axial tilt (obliquity) and eccentricity are controlled from the ``astronomy_mod`` module. 
 
 Dry Atmosphere
 ^^^^^^^^^^^^^^
@@ -37,21 +49,19 @@ Changing the dry atmosphere values allows atmospheres with a wide range of compo
 
 The dry air gas constant for any homogeneous atmosphere can be calculated from its chemical composition. It is calculated by dividing the universal gas constant :math:`R` by the average molar mass of the atmosphere.
 
-+------------+----------------------+-------------------------------------+-------------------------------------------------------+
-| Name       | Default              | Units                               | Description                                           |
-+============+======================+=====================================+=======================================================+
-|``pstd_mks``| 101325.0             | Pa / Nm :math:`^{-2}`               | Mean (reference) surface pressure (SI)                |
-+------------+----------------------+-------------------------------------+-------------------------------------------------------+
-|``pstd``    | 1.013250e06          | dyn :math:`\cdot` cm :math:`^{-2}`  | Mean (reference) surface pressure (cgs)               |
-+------------+----------------------+-------------------------------------+-------------------------------------------------------+
-|``rdgas``   | 287.04               | Jkg :math:`^{-1}`K :math:`^{-1}`    | Dry air gas constant                                  |
-+------------+----------------------+-------------------------------------+-------------------------------------------------------+
-|``kappa``   | 2/7                  | dimensionless                       | Heat capacity ratio ( :math:`\gamma` for an ideal gas)|
-+------------+----------------------+-------------------------------------+-------------------------------------------------------+
-|``cp_air``  | ``rvgas`` / ``kappa``| Jkg :math:`^{-1}`K :math:`^{-1}`    | Dry air heat capcity                                  |
-+------------+----------------------+-------------------------------------+-------------------------------------------------------+
++------------+----------------------------+-------------------------------------+-------------------------------------------------------+
+| Name       | Default                    | Units                               | Description                                           |
++============+============================+=====================================+=======================================================+
+|``pstd_mks``| :math:`101325.0`           | Pa / Nm :math:`^{-2}`               | Mean (reference) surface pressure (SI)                |
++------------+----------------------------+-------------------------------------+-------------------------------------------------------+
+|``pstd``    | :math:`1.013250\times 10^6`| dyn :math:`\cdot` cm :math:`^{-2}`  | Mean (reference) surface pressure (cgs)               |
++------------+----------------------------+-------------------------------------+-------------------------------------------------------+
+|``rdgas``   | :math:`287.04`             | Jkg :math:`^{-1}`K :math:`^{-1}`    | Dry air gas constant                                  |
++------------+----------------------------+-------------------------------------+-------------------------------------------------------+
+|``kappa``   | :math:`2/7`                | dimensionless                       | Heat capacity ratio ( :math:`\gamma` for an ideal gas)|
++------------+----------------------------+-------------------------------------+-------------------------------------------------------+
 
-.. note:: If the mean surface pressure value is changed here, it is necessary to also set ``reference_sea_level_press`` from the ``spectral_dynamics_nml`` namelist, else the output file will not extend to the pressure specified.
+.. note:: If the mean surface pressure value is changed here, it is necessary to also set ``reference_sea_level_press`` from the ``spectral_dynamics`` namelist, else the output file will not extend to the pressure specified.
 
 
 Moist Atmosphere
@@ -59,25 +69,42 @@ Moist Atmosphere
 
 With the addition of moist physics, a number of additional namelist parameters can be used to change the primary condensate present in the atmosphere. This allows atmospheres in temperature regimes significantly different from Earth to be modelled, including Titan, which has an active methane cycle.
 
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-| Name         | Default           | Units                            | Description                               |
-+==============+===================+==================================+===========================================+
-|``rvgas``     | 461.50            | Jkg :math:`^{-1}`K :math:`^{-1}` | Vapour gas constant                       |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``cp_vapor``  | 4 * ``rvgas``     | Jkg :math:`^{-1}`K :math:`^{-1}` | Vapour heat capacity                      |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``dens_vapor``| 1000              | kgm :math:`^{-3}`                | Density of condensate in the liquid phase |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``hlv``       | 2.500e6           | Jkg :math:`^{-1}`                | Latent heat of vapourisation of condensate|
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``hlf``       | 3.34e5            | Jkg :math:`^{-1}`                | Latent heat of fusion of condensate       |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``hls``       | ``hlv`` + ``hlf`` | Jkg :math:`^{-1}`                | Latent heat of sublimation of condensate  |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``tfreeze``   | 273.16            | K                                | Freezing point of condensate              |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
-|``tppress``   | 610.78            | Pa / Nm :math:`^{-2}`            | Triple point pressure of condensate       |
-+--------------+-------------------+----------------------------------+-------------------------------------------+
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+| Name          | Default                 | Units                            | Description                               |
++===============+=========================+==================================+===========================================+
+|``rvgas``      | :math:`461.50`          | Jkg :math:`^{-1}` K :math:`^{-1}`| Vapour gas constant                       |
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``dens_liquid``| :math:`1000`            | kgm :math:`^{-3}`                | Density of condensate in the liquid phase |
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``hlv``        | :math:`2.500\times 10^6`| Jkg :math:`^{-1}`                | Latent heat of vaporisation  of condensate|
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``hlf``        | :math:`3.34\times 10^5` | Jkg :math:`^{-1}`                | Latent heat of fusion of condensate       |
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``tfreeze``    | :math:`273.16`          | K                                | Freezing point of condensate              |
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``tppress``    | :math:`610.78`          | Pa / Nm :math:`^{-2}`            | Triple point pressure of condensate       |
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``es0``        | :math:`1.0`             | dimensionless                    | Humidity factor :math:`^\dagger`          |
++---------------+-------------------------+----------------------------------+-------------------------------------------+
+
+:math:`^\dagger`: The humidity factor controls the atmospheric humidity content via the expression for saturation vapor pressure *if* ``do_simple: True`` is set within the ``idealized_moist_phys`` namelist.
+
+Derived Constants
+^^^^^^^^^^^^^^^^^
+
+From the above namelist variables a few more derived atmospheric constants are calculated that are called by other modules, these are:
+
++------------+-----------------------+---------------------------------+------------------------------------------+
+| Name       | Default               | Units                           | Description                              |
++============+=======================+=================================+==========================================+
+|``cp_air``  | ``rvgas`` / ``kappa`` |Jkg :math:`^{-1}` K :math:`^{-1}`| Dry air heat capacity                    |
++------------+-----------------------+---------------------------------+------------------------------------------+
+|``cp_vapor``| :math:`4` * ``rvgas`` |Jkg :math:`^{-1}` K :math:`^{-1}`| Vapour heat capacity                     |
++------------+-----------------------+---------------------------------+------------------------------------------+
+|``hls``     |``hlv`` + ``hlf``      |Jkg :math:`^{-1}`                | Latent heat of sublimation of condensate |
++------------+-----------------------+---------------------------------+------------------------------------------+
+
+
 
 Relevant Modules
 ----------------
@@ -85,4 +112,4 @@ Since this module provides the definition of a number of physical constants, it 
 
 Authors
 -------
-This documentation was written by Daniel Williams, peer reviewed by YY, and quality controlled by ZZ.
+This documentation was written by Daniel Williams, peer reviewed by Stephen Thompson, and quality controlled by Ross Castle.

--- a/docs/source/modules/constants.rst
+++ b/docs/source/modules/constants.rst
@@ -21,11 +21,7 @@ Below are a set of controls that allow the physical size and rotation of a plane
 +---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
 |``omega``            | :math:`7.2921150\times 10^{-5}`  | rad :math:`\cdot` s :math:`^{-1}`| Rotation rate of planet                                   |
 +---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
-|``rotation_period``  | :math:`-1.0` (inactive)          | s                                | Rotation period of planet (overrides ``omega`` )          |
-+---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
 |``orbital_period``   | :math:`31557600`                 | s                                | Orbital period of planet                                  |
-+---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
-|``orbital_rate``     | :math:`2\pi` / ``orbital_period``| rad :math:`\cdot` s :math:`^{-1}`| Orbital rate of planet                                    |
 +---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
 |``solar_constant``   | :math:`1368.22`                  | Wm :math:`^{-2}`                 | Stellar irradiance                                        |
 +---------------------+----------------------------------+----------------------------------+-----------------------------------------------------------+
@@ -42,10 +38,10 @@ whereas setting ``earthday_multiple`` to true modifies the calculation to
 
 .. note:: Whilst the rotation and orbital rates are set within this module, other parameters associated with planetary motion such as axial tilt (obliquity) and eccentricity are controlled from the ``astronomy_mod`` module. 
 
-Dry Atmosphere
-^^^^^^^^^^^^^^
+Atmospheric Parameters
+^^^^^^^^^^^^^^^^^^^^^^
 
-Changing the dry atmosphere values allows atmospheres with a wide range of compositions to be studied, including both terrestrial planets (e.g. Earth) and gas giants such as Jupiter. In the case of Earth, the reference surface pressure is taken to be the mean sea level pressure.
+Changing the basic atmospheric properties allows atmospheres with a wide range of compositions to be studied, including both terrestrial planets (e.g. Earth/Mars) and gas giants such as Jupiter. In the case of Earth, the reference surface pressure is taken to be the mean sea level pressure.
 
 The dry air gas constant for any homogeneous atmosphere can be calculated from its chemical composition. It is calculated by dividing the universal gas constant :math:`R` by the average molar mass of the atmosphere.
 
@@ -60,51 +56,16 @@ The dry air gas constant for any homogeneous atmosphere can be calculated from i
 +------------+----------------------------+-------------------------------------+-------------------------------------------------------+
 |``kappa``   | :math:`2/7`                | dimensionless                       | Heat capacity ratio ( :math:`\gamma` for an ideal gas)|
 +------------+----------------------------+-------------------------------------+-------------------------------------------------------+
-
-.. note:: If the mean surface pressure value is changed here, it is necessary to also set ``reference_sea_level_press`` from the ``spectral_dynamics`` namelist, else the output file will not extend to the pressure specified.
-
-
-Moist Atmosphere
-^^^^^^^^^^^^^^^^
-
-With the addition of moist physics, a number of additional namelist parameters can be used to change the primary condensate present in the atmosphere. This allows atmospheres in temperature regimes significantly different from Earth to be modelled, including Titan, which has an active methane cycle.
-
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-| Name          | Default                 | Units                            | Description                               |
-+===============+=========================+==================================+===========================================+
-|``rvgas``      | :math:`461.50`          | Jkg :math:`^{-1}` K :math:`^{-1}`| Vapour gas constant                       |
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-|``dens_liquid``| :math:`1000`            | kgm :math:`^{-3}`                | Density of condensate in the liquid phase |
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-|``hlv``        | :math:`2.500\times 10^6`| Jkg :math:`^{-1}`                | Latent heat of vaporisation  of condensate|
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-|``hlf``        | :math:`3.34\times 10^5` | Jkg :math:`^{-1}`                | Latent heat of fusion of condensate       |
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-|``tfreeze``    | :math:`273.16`          | K                                | Freezing point of condensate              |
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-|``tppress``    | :math:`610.78`          | Pa / Nm :math:`^{-2}`            | Triple point pressure of condensate       |
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
-|``es0``        | :math:`1.0`             | dimensionless                    | Humidity factor :math:`^\dagger`          |
-+---------------+-------------------------+----------------------------------+-------------------------------------------+
+|``es0``     | :math:`1.0`                | dimensionless                       | Humidity factor :math:`^\dagger`                      |
++------------+----------------------------+-------------------------------------+-------------------------------------------------------+
 
 :math:`^\dagger`: The humidity factor controls the atmospheric humidity content via the expression for saturation vapor pressure *if* ``do_simple: True`` is set within the ``idealized_moist_phys`` namelist.
 
-Derived Constants
+.. note:: If the mean surface pressure value is changed here, it is necessary to also set ``reference_sea_level_press`` from the ``spectral_dynamics`` namelist, else the output file will not extend to the pressure specified.
+
+Moist Atmospheres
 ^^^^^^^^^^^^^^^^^
-
-From the above namelist variables a few more derived atmospheric constants are calculated that are called by other modules, these are:
-
-+------------+-----------------------+---------------------------------+------------------------------------------+
-| Name       | Default               | Units                           | Description                              |
-+============+=======================+=================================+==========================================+
-|``cp_air``  | ``rvgas`` / ``kappa`` |Jkg :math:`^{-1}` K :math:`^{-1}`| Dry air heat capacity                    |
-+------------+-----------------------+---------------------------------+------------------------------------------+
-|``cp_vapor``| :math:`4` * ``rvgas`` |Jkg :math:`^{-1}` K :math:`^{-1}`| Vapour heat capacity                     |
-+------------+-----------------------+---------------------------------+------------------------------------------+
-|``hls``     |``hlv`` + ``hlf``      |Jkg :math:`^{-1}`                | Latent heat of sublimation of condensate |
-+------------+-----------------------+---------------------------------+------------------------------------------+
-
-
+We hope to be able to introduce controls for moist atmospheres in a future update to Isca. This will allow condensable species other than water to be easily modelled.
 
 Relevant Modules
 ----------------

--- a/docs/source/modules/constants.rst
+++ b/docs/source/modules/constants.rst
@@ -79,7 +79,9 @@ With the addition of moist physics, a number of additional namelist parameters c
 |``tppress``   | 610.78            | Pa / Nm :math:`^{-2}`            | Triple point pressure of condensate       |
 +--------------+-------------------+----------------------------------+-------------------------------------------+
 
-
+Relevant Modules
+----------------
+Since this module provides the definition of a number of physical constants, it is used by most other modules that exist within the Isca framework.
 
 Authors
 -------

--- a/docs/source/modules/index.rst
+++ b/docs/source/modules/index.rst
@@ -9,6 +9,7 @@ Components of Isca
 
    dynamics
    physics
+   constants
    output
    idealised_moist_phys
    two_stream_gray_rad


### PR DESCRIPTION
This is just a first draft of some documentation for the constants module (to be continued in new year).

Note that this contains a number of new namelist parameters that are not currently present, especially those relating to moist atmospheric parameters. This sets the scene for an updated `constants.f90` (and associated modules) that generalises the atmosphere to more easily allow for a wider range of configurations beyond water-based Earth-like systems, as discussed with @sit23. Modifications to the modules themselves will form part of a future PR, and this should not be accepted until then.

I also suspect that `ptsd` may be surplus to requirements, but I'm not sure if it's still used anywhere.