### PR TITLE
[WIP] working version on gfortran11 on macOS v11.2

### DIFF
--- a/src/extra/env/gfortran_mac
+++ b/src/extra/env/gfortran_mac
@@ -1,0 +1,9 @@
+echo Loading basic gfortran environment
+
+# this defaults to ia64, but we will use gfortran, not ifort
+export GFDL_MKMF_TEMPLATE=gfort
+export F90=mpifort
+export CC=mpicc
+export CDEFS=" -DMACOS "
+export NETCDF_LIBS=`nf-config --flibs`
+

--- a/src/extra/python/isca/templates/compile.sh
+++ b/src/extra/python/isca/templates/compile.sh
@@ -18,9 +18,9 @@ template_debug={{ template_dir }}/mkmf.template.debug
 execdir={{ execdir }}        # where code is compiled and executable is created
 executable={{ executable_name }}
 
-netcdf_flags=`nf-config --fflags --flibs`
+#netcdf_flags=`nf-config --fflags --flibs`
 
-ulimit -s unlimited # Set stack size to unlimited
+#ulimit -s unlimited # Set stack size to unlimited
 export MALLOC_CHECK_=0
 
 # 3. compile the mppncombine tool if it hasn't yet been done.
@@ -53,13 +53,13 @@ if [ $debug == True ]; then
  echo "Compiling in debug mode"
 
 # execute mkmf to create makefile
-cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 {{compile_flags}}"
+cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 ${CDEFS} {{compile_flags}}"
 $mkmf  -a $sourcedir -t $template_debug -p $executable -c "$cppDefs" $pathnames $sourcedir/shared/include $sourcedir/shared/mpp/include
 
 else
 
 # execute mkmf to create makefile
-cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 {{compile_flags}}"
+cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 ${CDEFS} {{compile_flags}}"
 $mkmf  -a $sourcedir -t $template -p $executable -c "$cppDefs" $pathnames $sourcedir/shared/include $sourcedir/shared/mpp/include
 
 fi

--- a/src/extra/python/isca/templates/mkmf.template.gfort
+++ b/src/extra/python/isca/templates/mkmf.template.gfort
@@ -2,7 +2,6 @@
 # typical use with mkmf
 # mkmf -t template.ifc -c"-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
 CPPFLAGS = -I/usr/local/include
-NETCDF_LIBS = `nf-config --fflags  --flibs`
 
 # FFLAGS:
 #  -cpp: Use the fortran preprocessor
@@ -18,8 +17,8 @@ NETCDF_LIBS = `nf-config --fflags  --flibs`
 
 FFLAGS = $(CPPFLAGS) $(NETCDF_LIBS) -cpp -fcray-pointer \
           -O2 -ffree-line-length-none -fno-range-check \
-           -fdefault-real-8 -fdefault-double-8
-
+          -fallow-argument-mismatch -fallow-invalid-boz \
+          -fdefault-real-8 -fdefault-double-8
 FC = $(F90)
 LD = $(F90) $(NETCDF_LIBS)
 

--- a/src/extra/python/isca/templates/run.sh
+++ b/src/extra/python/isca/templates/run.sh
@@ -5,7 +5,7 @@ rundir={{ rundir }}  # change this if you're rerunning from the output directory
 
 source {{ env_source }}
 
-ulimit -s unlimited
+#ulimit -s unlimited
 
 debug={{ run_idb }}                                     # logical to identify if running in debug mode or not
 

--- a/src/shared/mosaic/create_xgrid.c
+++ b/src/shared/mosaic/create_xgrid.c
@@ -96,6 +96,14 @@ void get_grid_great_circle_area_(const int *nlon, const int *nlat, const double 
 }
 #endif
 
+int isHeadNode_b(struct Node *list, struct Node nodeIn)
+{
+  if(sameNode(*list, nodeIn))
+    return 1;
+  else
+    return 0;
+}
+
 void get_grid_great_circle_area(const int *nlon, const int *nlat, const double *x, const double *y, const double *z, double *area)
 {
   int nx, ny, nxp, i, j, n_in;
@@ -1360,7 +1368,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
       error_handler("firstIntersect is not in the subjList");
     }
     addNode(polyList, firstIntersect);
-    if( isHeadNode(intersectList, firstIntersect) ) {
+    if( isHeadNode_b(intersectList, firstIntersect) ) {
       temp = intersectList;
       intersectList = getNextNode(intersectList);
       free(temp);
@@ -1431,7 +1439,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	else {
 	  addNode(polyList, *temp2);
 	  if(temp2IsIntersect) { /* remove temp2 from intersectList */
-	    if( isHeadNode(intersectList, *temp2) ) {
+	    if( isHeadNode_b(intersectList, *temp2) ) {
 	      temp = intersectList;
 	      intersectList = getNextNode(intersectList);
 	      free(temp);
@@ -1457,7 +1465,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 
       /* add curIntersect to polyList and remove it from intersectList and curList */
       addNode(polyList, curIntersect);
-      if( isHeadNode(intersectList, curIntersect) ) {
+      if( isHeadNode_b(intersectList, curIntersect) ) {
 	temp = intersectList;
 	intersectList = getNextNode(intersectList);
 	free(temp);
@@ -1466,7 +1474,7 @@ int clip_2dx2d_great_circle(const double x1_in[], const double y1_in[], const do
 	removeNode(intersectList, curIntersect);
       nintersect--;
       
-      if( isHeadNode(curList, curIntersect) ) {
+      if( isHeadNode_b(curList, curIntersect) ) {
 	temp = curList;
 	curList = getNextNode(curList);
 	if( curListNum == 0 )

--- a/src/shared/mpp/affinity.c
+++ b/src/shared/mpp/affinity.c
@@ -21,6 +21,13 @@
 
 #define _GNU_SOURCE
 
+#ifdef MACOS
+
+int get_cpu_affinity(void) { return -1; };
+void set_cpu_affinity( int cpu ) {};
+
+#else
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,8 +71,6 @@ int get_cpu_affinity(void)
   return (last_cpu == -1) ? first_cpu : -1;
 }
 
-int get_cpu_affinity_(void) { return get_cpu_affinity(); }	/* Fortran interface */
-
 
 /*
  * Set CPU affinity to one core.
@@ -81,4 +86,7 @@ void set_cpu_affinity( int cpu )
   }
 }
 
+#endif
+
+int get_cpu_affinity_(void) { return get_cpu_affinity(); } /* Fortran interface */
 void set_cpu_affinity_(int *cpu) { set_cpu_affinity(*cpu); }	/* Fortran interface */


### PR DESCRIPTION
**I am opening the PR as a way to share and discuss but shouldnt be merged in its current form** 

This follows up on https://github.com/ExeClim/Isca/issues/210 and are modifications which eventually allowed me to compile and run `held_suarez_test_case.py` on a Mac (running OS 11.2). 

There were several types of issues as you'll see, some of which I uncovered after upgrading to the latest gfortran compiler (v11)

- linux system calls which error out on Mac; some I just commented out for now; the affinity part is switched off via a `MACOS` cpp flag; more or less as done by @jamesp  in 2018  (https://github.com/jamesp/Isca/tree/mac)
- the `-fallow-argument-mismatch` and `-fallow-invalid-boz` part is related to warnings that have recently been turned into errors (the options revert to warnings). Would need a switch like in https://github.com/MITgcm/MITgcm/pull/480 probably for gfortran < v10
- in `create_xgrid.c` I needed to add a definition of `isHeadNode_b` (same as in `mosaic_util.c` but for the name)
- added `gfortran_mac` option file

Maybe this could get reviewed and merged after some revision. Please chime in
