### PR TITLE
Sorting out check_nml_error calls

### DIFF
--- a/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
+++ b/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
@@ -6,7 +6,7 @@ module idealized_moist_phys_mod
   use fms_mod, only: open_namelist_file, close_file
 #endif
 
-use fms_mod, only: write_version_number, file_exist, close_file, stdlog, error_mesg, NOTE, FATAL, read_data, field_size, uppercase, mpp_pe
+use fms_mod, only: write_version_number, file_exist, close_file, stdlog, error_mesg, NOTE, FATAL, read_data, field_size, uppercase, mpp_pe, check_nml_error
 
 use           constants_mod, only: grav, rdgas, rvgas, cp_air, PSTD_MKS, dens_h2o !mj cp_air needed for rrtmg !s pstd_mks needed for pref calculation
 
@@ -308,7 +308,7 @@ real, dimension (size(rad_lonb_2d,1)-1, size(rad_latb_2d,2)-1) :: sgsmtn !s adde
 
 !s added for land reading
 integer, dimension(4) :: siz
-integer :: global_num_lon, global_num_lat
+integer :: global_num_lon, global_num_lat, ierr
 character(len=12) :: ctmp1='     by     ', ctmp2='     by     '
 !s end added for land reading
 
@@ -327,10 +327,12 @@ call write_version_number(version, tagname)
 
 #ifdef INTERNAL_FILE_NML
    read (input_nml_file, nml=idealized_moist_phys_nml, iostat=io)
+   ierr = check_nml_error (io,'idealized_moist_phys_nml')
 #else
    if ( file_exist('input.nml') ) then
       nml_unit = open_namelist_file()
       read (nml_unit, idealized_moist_phys_nml, iostat=io)
+      ierr = check_nml_error (io,'idealized_moist_phys_nml')
       call close_file(nml_unit)
    endif
 #endif

--- a/src/coupler/surface_flux.F90
+++ b/src/coupler/surface_flux.F90
@@ -910,6 +910,7 @@ subroutine surface_flux_init
   ! read namelist
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, surface_flux_nml, iostat=io)
+      ierr = check_nml_error(io,'surface_flux_nml')
 #else
   if ( file_exist('input.nml')) then
      unit = open_namelist_file ()

--- a/src/extra/python/scripts/find_namelists_to_check.py
+++ b/src/extra/python/scripts/find_namelists_to_check.py
@@ -1,0 +1,45 @@
+import subprocess
+import os
+import glob
+from pathlib import Path
+import pdb
+
+#find the location of the source code
+GFDL_BASE = os.environ['GFDL_BASE']
+
+#setup some output dictionaries and lists
+fortran_file_dict = {}
+includes_namelist_dict = {}
+includes_check_namelist_dict = {}
+namelists_to_flag = []
+
+#find ALL of the fortran files within GFDL_BASE/src directory
+for path in Path(f'{GFDL_BASE}/src/').rglob('*.*90'):
+    #exclude files with ._ at the start
+    if path.name[0:2]!='._':
+        #add all the remaining files to a dictionary
+        fortran_file_dict[path.name] = path
+    
+#go through each file and check if it contains a namelist, and if it does namelist checking    
+for file_name in fortran_file_dict.keys():
+    file_path = fortran_file_dict[file_name]
+    namelist_in_file=False
+    check_namelist_in_file=False
+    #open each of the fortran files
+    with open(file_path, 'r') as read_obj:
+        for line in read_obj:
+            #check if it contains a namelist
+            if 'namelist /' in line and not namelist_in_file:
+                namelist_in_file=True
+            # does it contain the check_nml_error command? 
+            if 'check_nml_error(' in line and not check_namelist_in_file:
+                check_namelist_in_file=True
+
+    #make a list of those files that do have a namelist but don't do checking            
+    if namelist_in_file and not check_namelist_in_file:
+        namelists_to_flag.append(file_name)
+
+    #keep a record of the files that include a namelist
+    includes_namelist_dict[file_name]=namelist_in_file
+    #keep a record of the files that do and don't do namelist checking
+    includes_check_namelist_dict[file_name]=check_namelist_in_file

--- a/src/extra/python/scripts/find_namelists_to_check.py
+++ b/src/extra/python/scripts/find_namelists_to_check.py
@@ -4,6 +4,9 @@ import glob
 from pathlib import Path
 import pdb
 
+#A script to find the fortran files within Isca's src directory
+#that include namelists, and to check if namelist checking is done.
+
 #find the location of the source code
 GFDL_BASE = os.environ['GFDL_BASE']
 
@@ -29,6 +32,8 @@ for path in Path(f'{GFDL_BASE}/src/').rglob('*.*90'):
 #go through each file and check if it contains a namelist, and if it does namelist checking    
 for file_name in fortran_file_dict.keys():
     file_path = fortran_file_dict[file_name]
+
+    #initialise some of the checking variables
     namelist_in_file=False
     check_namelist_in_file=False
     number_of_checks=0
@@ -42,31 +47,42 @@ for file_name in fortran_file_dict.keys():
             # does it contain the check_nml_error command? 
             if 'check_nml_error' in line and not check_namelist_in_file:
                 check_namelist_in_file=True
+            # count how many times this string is mentioned
             if 'check_nml_error' in line:
                 number_of_checks=number_of_checks+1
+            #check if there's more than one type of namelist reading available
             if '#ifdef INTERNAL_FILE_NML' in line and not if_def_internal_nml_in_file:
                 if_def_internal_nml_in_file=True                
 
-    #make a list of those files that do have a namelist but don't do checking            
+    #make a list of those files that do have a namelist     
     if namelist_in_file:
         files_with_namelists.append(file_name)
 
+    #make a list of those files that do have a namelist but don't do checking       
     if namelist_in_file and not check_namelist_in_file:
         namelists_to_flag.append(file_name)
 
+    #making a list of files that have namelists, that read them in more than one way, and have fewer than 3 mentions of check_nml_error. This is to catch cases where there is some namelist checking taking place, but it's not on all the methods of namelist reading.
     if namelist_in_file and if_def_internal_nml_in_file and number_of_checks<3:
         namelists_to_flag_possible.append(file_name)
 
     #keep a record of the files that include a namelist
     includes_namelist_dict[file_name]=namelist_in_file
+
     #keep a record of the files that do and don't do namelist checking
     includes_check_namelist_dict[file_name]=check_namelist_in_file
 
+    #keep a record of the number of checks taking place
     n_check_namelist_dict[file_name] = number_of_checks
 
+#create a list of files that appear in namelists_to_flag_possible
 list_of_filepaths_to_check = [str(fortran_file_dict[path]) for path in namelists_to_flag_possible]
 
+#print the number of checks
 print([n_check_namelist_dict[path] for path in namelists_to_flag_possible])
 
+#print the list of files
 print(namelists_to_flag_possible)
+
+#print their directories
 print(list_of_filepaths_to_check)

--- a/src/extra/python/scripts/find_namelists_to_check.py
+++ b/src/extra/python/scripts/find_namelists_to_check.py
@@ -11,7 +11,13 @@ GFDL_BASE = os.environ['GFDL_BASE']
 fortran_file_dict = {}
 includes_namelist_dict = {}
 includes_check_namelist_dict = {}
+n_check_namelist_dict = {}
+if_def_internal_nml_dict={}
+
+files_with_namelists = []
 namelists_to_flag = []
+namelists_to_flag_possible = []
+
 
 #find ALL of the fortran files within GFDL_BASE/src directory
 for path in Path(f'{GFDL_BASE}/src/').rglob('*.*90'):
@@ -25,6 +31,8 @@ for file_name in fortran_file_dict.keys():
     file_path = fortran_file_dict[file_name]
     namelist_in_file=False
     check_namelist_in_file=False
+    number_of_checks=0
+    if_def_internal_nml_in_file=False
     #open each of the fortran files
     with open(file_path, 'r') as read_obj:
         for line in read_obj:
@@ -34,17 +42,31 @@ for file_name in fortran_file_dict.keys():
             # does it contain the check_nml_error command? 
             if 'check_nml_error' in line and not check_namelist_in_file:
                 check_namelist_in_file=True
+            if 'check_nml_error' in line:
+                number_of_checks=number_of_checks+1
+            if '#ifdef INTERNAL_FILE_NML' in line and not if_def_internal_nml_in_file:
+                if_def_internal_nml_in_file=True                
 
     #make a list of those files that do have a namelist but don't do checking            
+    if namelist_in_file:
+        files_with_namelists.append(file_name)
+
     if namelist_in_file and not check_namelist_in_file:
         namelists_to_flag.append(file_name)
+
+    if namelist_in_file and if_def_internal_nml_in_file and number_of_checks<3:
+        namelists_to_flag_possible.append(file_name)
 
     #keep a record of the files that include a namelist
     includes_namelist_dict[file_name]=namelist_in_file
     #keep a record of the files that do and don't do namelist checking
     includes_check_namelist_dict[file_name]=check_namelist_in_file
 
-list_of_filepaths_to_check = [str(fortran_file_dict[path]) for path in namelists_to_flag]
+    n_check_namelist_dict[file_name] = number_of_checks
 
-print(namelists_to_flag)
+list_of_filepaths_to_check = [str(fortran_file_dict[path]) for path in namelists_to_flag_possible]
+
+print([n_check_namelist_dict[path] for path in namelists_to_flag_possible])
+
+print(namelists_to_flag_possible)
 print(list_of_filepaths_to_check)

--- a/src/extra/python/scripts/find_namelists_to_check.py
+++ b/src/extra/python/scripts/find_namelists_to_check.py
@@ -32,7 +32,7 @@ for file_name in fortran_file_dict.keys():
             if 'namelist /' in line and not namelist_in_file:
                 namelist_in_file=True
             # does it contain the check_nml_error command? 
-            if 'check_nml_error(' in line and not check_namelist_in_file:
+            if 'check_nml_error' in line and not check_namelist_in_file:
                 check_namelist_in_file=True
 
     #make a list of those files that do have a namelist but don't do checking            
@@ -43,3 +43,8 @@ for file_name in fortran_file_dict.keys():
     includes_namelist_dict[file_name]=namelist_in_file
     #keep a record of the files that do and don't do namelist checking
     includes_check_namelist_dict[file_name]=check_namelist_in_file
+
+list_of_filepaths_to_check = [str(fortran_file_dict[path]) for path in namelists_to_flag]
+
+print(namelists_to_flag)
+print(list_of_filepaths_to_check)

--- a/src/shared/astronomy/astronomy.f90
+++ b/src/shared/astronomy/astronomy.f90
@@ -296,6 +296,7 @@ real,   dimension(:,:), intent(in), optional   :: lonb
 !-----------------------------------------------------------------------
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, astronomy_nml, iostat=io)
+      ierr = check_nml_error(io,'astronomy_nml')
 #else
       if ( file_exist('input.nml')) then
         unit =  open_namelist_file ( )

--- a/src/shared/axis_utils/axis_utils.F90
+++ b/src/shared/axis_utils/axis_utils.F90
@@ -854,6 +854,7 @@ integer           :: unit, ierr, io
   !---reading namelist 
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, test_axis_utils_nml, iostat=io)
+      ierr = check_nml_error(io,'test_axis_utils_nml')  ! also initializes nml error codes
 #else
   if(file_exist('input.nml')) then
     unit =  open_namelist_file()

--- a/src/shared/horiz_interp/horiz_interp.F90
+++ b/src/shared/horiz_interp/horiz_interp.F90
@@ -1288,6 +1288,7 @@ implicit none
   !--- read namelist
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, test_horiz_interp_nml, iostat=io)
+      ierr = check_nml_error(io, 'test_horiz_interp_nml')
 #else
   if (file_exist('input.nml')) then
      ierr=1

--- a/src/shared/horiz_interp/horiz_interp_spherical.F90
+++ b/src/shared/horiz_interp/horiz_interp_spherical.F90
@@ -104,6 +104,7 @@ contains
     call write_version_number (version, tagname)
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, horiz_interp_spherical_nml, iostat=io)
+      ierr = check_nml_error(io,'horiz_interp_spherical_nml')  ! also initializes nml error codes
 #else
     if (file_exist('input.nml')) then
        unit = open_namelist_file ( )

--- a/src/shared/sat_vapor_pres/sat_vapor_pres.F90
+++ b/src/shared/sat_vapor_pres/sat_vapor_pres.F90
@@ -2278,6 +2278,7 @@ real,  intent(in),              optional :: hc
 !---- read namelist input ----
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, sat_vapor_pres_nml, iostat=io)
+      ierr = check_nml_error(io,'sat_vapor_pres_nml')
 #else
   if (file_exist('input.nml')) then
      unit = open_namelist_file ( )

--- a/src/shared/time_interp/time_interp.F90
+++ b/src/shared/time_interp/time_interp.F90
@@ -233,6 +233,7 @@ contains
 
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, time_interp_nml, iostat=io)
+      ierr = check_nml_error (io, 'time_interp_nml')
 #else
    namelist_unit = open_namelist_file()
    ierr=1

--- a/src/shared/time_manager/get_cal_time.F90
+++ b/src/shared/time_manager/get_cal_time.F90
@@ -188,6 +188,7 @@ logical :: permit_conversion_local
 if(.not.module_is_initialized) then
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, get_cal_time_nml, iostat=io)
+      ierr = check_nml_error (io, 'get_cal_time_nml')
 #else
   namelist_unit = open_namelist_file()
   ierr=1

--- a/src/shared/time_manager/time_manager.F90
+++ b/src/shared/time_manager/time_manager.F90
@@ -3479,6 +3479,7 @@ logical :: test17=.true.,test18=.true.,test19=.true.
 
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, test_nml, iostat=io)
+      ierr = check_nml_error (io, 'test_nml')
 #else
  nmlunit = open_namelist_file()
  ierr=1

--- a/src/shared/topography/gaussian_topog.F90
+++ b/src/shared/topography/gaussian_topog.F90
@@ -270,6 +270,7 @@ subroutine read_namelist
 
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, gaussian_topog_nml, iostat=io)
+      ierr = check_nml_error(io,'gaussian_topog_nml')
 #else
    if ( file_exist('input.nml')) then
       unit = open_namelist_file ( )

--- a/src/shared/topography/topography.F90
+++ b/src/shared/topography/topography.F90
@@ -920,6 +920,7 @@ subroutine read_namelist
 
 #ifdef INTERNAL_FILE_NML
       read (input_nml_file, topography_nml, iostat=io)
+      ierr = check_nml_error(io,'topography_nml')
 #else
    if ( file_exist('input.nml')) then
       unit = open_namelist_file ( )


### PR DESCRIPTION
Many of the fortran modules in Isca rely on reading namelists to set their parameters. The FMS upon which Isca is built has a built-in-method (`check_nml_error`) to make sure that the namelists are read in properly. This is to prevent problems such as when a namelist parameter is put in the namelist for a module that doesn't exist in that module. When this happens and `check_nml_error` is _not_ called, the reading of the namelist for that module fails, but the user is given no warning. The module in question then runs with its default values for all namelist parameters. This is clearly a bad thing, as you want to know when the namelist is not being read. On the other hand, when check_nml_error is run and it finds a problem as just descried, the model throws a fatal error.

As described in issue #48, not all of Isca's modules do this error checking. This P/R aims to add namelist error checking to all remaining fortran files that include namelists. I first wrote a python script to find all of Isca's fortran files, and then find those that do error checking, and those that do not. I then manually went through and added the checks to all the modules it brought up. This should mean that namelist error checking is done my every module that requires it.

The trip tests have been performed for these files, and they pass:
```
Results for all of the test cases ran comparing 2b603fa and 3b170ce are as follows...
axisymmetric : pass
bucket_model : pass
frierson : pass
giant_planet : pass
held_suarez : pass
MiMA : pass
realistic_continents_fixed_sst : pass
realistic_continents_variable_qflux : pass
socrates_aquaplanet : pass
top_down_test : pass
variable_co2_grey : pass
variable_co2_rrtm : pass
ape_aquaplanet : pass
Congratulations, all tests have passed
```