### PR TITLE
Add option to interpolator to allow interpolation of dry data

### DIFF
--- a/src/extra/python/isca/util.py
+++ b/src/extra/python/isca/util.py
@@ -131,7 +131,7 @@ def delete_all_restarts(exp, exceptions=None):
 
 
 
-def interpolate_output(infile, outfile, all_fields=True, var_names=[], p_levs = "input"):
+def interpolate_output(infile, outfile, all_fields=True, var_names=[], p_levs = "input", dry=False):
     """Interpolate data from sigma to pressure levels. Includes option to remove original file.
 
     This is a very thin wrapper around the plevel.sh script found in
@@ -170,8 +170,10 @@ def interpolate_output(infile, outfile, all_fields=True, var_names=[], p_levs = 
     plev = " ".join("{:.0f}".format(x) for x in reversed(sorted(levels)))
     if all_fields:
         interpolator = interpolator.bake('-a')
+    if dry:
+        interpolator = interpolator.bake('-0')
     var_names = ' '.join(var_names)
-
+    
     interpolator('-i', infile, '-o', outfile, '-p', plev, var_names)
 
 


### PR DESCRIPTION
I realised my interpolator wrapper didn't allow sphum to be set to 0 when height is calculated for dry simulations. I've added an option to do this. 

This is independent of any model source code and run scripts, just a python tool for postprocessing, but I can do trip tests later if there are any concerns before merging.