### PR TITLE
Allocate v_10m in idealized_moist_phys.F90

### DIFF
--- a/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
+++ b/src/atmos_spectral/driver/solo/idealized_moist_phys.F90
@@ -481,6 +481,7 @@ allocate(ex_del_h    (is:ie, js:je))
 allocate(ex_del_q    (is:ie, js:je))
 allocate(temp_2m     (is:ie, js:je))
 allocate(u_10m       (is:ie, js:je))
+allocate(v_10m       (is:ie, js:je))
 allocate(q_2m        (is:ie, js:je))
 allocate(rh_2m       (is:ie, js:je))
 allocate(land        (is:ie, js:je)); land = .false.


### PR DESCRIPTION
Allocation of v_10m was deleted during cleaning of initials from code causing segfaults when code is compiled with gfortran. This bug fix corrects this deletion.

With this fix the code compiles and runs with gfortran. Trip tests are running now.