### PR TITLE
Small fixes for test cases that fail under gfortran

### DIFF
--- a/exp/test_cases/axisymmetric/axisymmetric_test_case.py
+++ b/exp/test_cases/axisymmetric/axisymmetric_test_case.py
@@ -141,7 +141,7 @@ exp.namelist = namelist = Namelist({
     'rrtm_radiation_nml': {
         'do_read_ozone':True,
         'ozone_file':'ozone_1990',
-        'dt_rad': 3600. #Set RRTM radiation timestep to 3600 seconds, meaning it runs every 5 atmospheric timesteps
+        'dt_rad': 3600, #Set RRTM radiation timestep to 3600 seconds, meaning it runs every 5 atmospheric timesteps
     },
 
     # FMS Framework configuration

--- a/exp/test_cases/trip_test/trip_test_functions.py
+++ b/exp/test_cases/trip_test/trip_test_functions.py
@@ -176,6 +176,7 @@ def conduct_comparison_on_test_case(base_commit, later_commit, test_case_name, r
     diag_use = define_simple_diag_table()
     test_pass = True
     run_complete = True
+    compile_successful=True
 
     #Do the run for each of the commits in turn
     for s in [base_commit, later_commit]:
@@ -184,17 +185,23 @@ def conduct_comparison_on_test_case(base_commit, later_commit, test_case_name, r
             cb = SocratesCodeBase(repo=repo_to_use, commit=s)
         else:
             cb = IscaCodeBase(repo=repo_to_use, commit=s)
-        cb.compile()
-        exp = Experiment(exp_name, codebase=cb)
-        exp.namelist = nml_use.copy()
-        exp.diag_table = diag_use
-        exp.inputfiles = input_files_use
+        try:
+            cb.compile()
+            exp = Experiment(exp_name, codebase=cb)
+            exp.namelist = nml_use.copy()
+            exp.diag_table = diag_use
+            exp.inputfiles = input_files_use
 
-        #Only run for 3 days to keep things short.
-        exp.update_namelist({
-        'main_nml': {
-        'days': 3,
-        }})
+            #Only run for 3 days to keep things short.
+            exp.update_namelist({
+            'main_nml': {
+            'days': 3,
+            }})
+        except:
+            run_complete = False
+            test_pass = False      
+            compile_successful=False                  
+            continue            
 
 
         try:
@@ -239,7 +246,12 @@ def conduct_comparison_on_test_case(base_commit, later_commit, test_case_name, r
             return_test_result = 'fail'
 
     else:
-        print('Test failed for '+test_case_name+' because the run crashed.')
+        if compile_successful:
+            #This means that the compiles were both successful, but at least one of the runs crashed.
+            print('Test failed for '+test_case_name+' because the run crashed.')
+        else:
+            print('Test failed for '+test_case_name+' because at least one of the runs failed to compile.')
+
         return_test_result = 'fail'
 
 

--- a/src/atmos_param/hs_forcing/hs_forcing.F90
+++ b/src/atmos_param/hs_forcing/hs_forcing.F90
@@ -985,7 +985,7 @@ real, intent(in),  dimension(:,:,:), optional :: mask
                 teq(:,:,k) = max(teq(:,:,k), tstr(:,:))
 		elseif (stratosphere_t_option == 'extend_tp') then
 			do i=1,size(t,1)
-			do j=1,size(t,1)
+			do j=1,size(t,2)
                 if (zfull(i,j,k)/1000 >= h_trop(i,j)) then
                     teq(i,j,k) = t_trop(i,j)
                 endif

--- a/src/atmos_param/rayleigh_bottom_drag/rayleigh_bottom_drag.F90
+++ b/src/atmos_param/rayleigh_bottom_drag/rayleigh_bottom_drag.F90
@@ -124,27 +124,22 @@ contains
     real, intent(in)                       ::  delta_t
     real, intent(in), dimension (:,:)       :: lat
     
-    real, optional, dimension (:,:,:)       :: ug_previous, vg_previous, & 
+    real, intent(in), dimension (:,:,:)       :: ug_previous, vg_previous, & 
                                         p_half_previous, p_full_previous
     
     real, intent(inout), dimension(:,:,:)   :: dt_ug, dt_vg, dt_tg
     real, intent(out),   dimension(:,:,:)   :: dissipative_heat
 
 
-    if(present(ug_previous)) then
-          if (do_drag_at_surface) then
-             call surface_drag(Time, delta_t, lat, is, js, ug_previous, vg_previous,    &
-                            p_half_previous,  p_full_previous, dt_ug, dt_vg,    &
-                            dt_tg, dissipative_heat)
-	  else 
-             call interior_drag(Time, delta_t, lat, is, js, ug_previous, vg_previous,    &
-                            p_half_previous,  p_full_previous, dt_ug, dt_vg,    &
-                            dt_tg, dissipative_heat)
-          endif
-    else
-       call error_mesg('compute_rayleigh_bottom_drag',                         &
-            'ug_previous is not present',fatal)
-    end if
+   if (do_drag_at_surface) then
+      call surface_drag(Time, delta_t, lat, is, js, ug_previous, vg_previous,    &
+                     p_half_previous,  p_full_previous, dt_ug, dt_vg,    &
+                     dt_tg, dissipative_heat)
+   else 
+      call interior_drag(Time, delta_t, lat, is, js, ug_previous, vg_previous,    &
+                     p_half_previous,  p_full_previous, dt_ug, dt_vg,    &
+                     dt_tg, dissipative_heat)
+   endif
 
   end subroutine compute_rayleigh_bottom_drag
 
@@ -158,9 +153,9 @@ contains
     integer, intent(in)                       :: is, js
     real,    intent(in),    dimension (:,:,:) :: ug, vg, p_full, p_half
     real,    intent(inout), dimension(:,:,:)  :: dt_ug, dt_vg, dt_tg
-    real,    dimension(size(ug,1),size(ug,2)) :: sigma, sigma_norm, sigma_max
     real,    intent(out),   dimension(:,:,:)  :: dissipative_heat 
-    
+
+    real,    dimension(size(ug,1),size(ug,2)) :: sigma, sigma_norm, sigma_max
     real, dimension(size(ug,1),size(ug,2),size(ug,3)):: dt_u_temp, dt_v_temp
     real, dimension(size(ug,2))  :: drag_coeff
     integer :: j, k, num_level 
@@ -234,9 +229,9 @@ contains
     integer, intent(in)                       :: is, js
     real,    intent(in),    dimension (:,:,:) :: ug, vg, p_full, p_half
     real,    intent(inout), dimension(:,:,:)  :: dt_ug, dt_vg, dt_tg
-    real,    dimension(size(ug,1),size(ug,2)) :: sigma, sigma_norm, sigma_max
     real,    intent(out),   dimension(:,:,:)  :: dissipative_heat 
-    
+
+    real,    dimension(size(ug,1),size(ug,2)) :: sigma, sigma_norm, sigma_max
     real, dimension(size(ug,1),size(ug,2),size(ug,3)):: dt_u_temp, dt_v_temp
     real, dimension(size(ug,2))  :: drag_coeff
     integer :: j, k, num_level 

--- a/src/atmos_param/socrates/interface/socrates_interface.F90
+++ b/src/atmos_param/socrates/interface/socrates_interface.F90
@@ -155,7 +155,7 @@ write(stdlog_unit, socrates_rad_nml)
 
           if(dt_rad_avg .le. 0) dt_rad_avg = dt_rad
 
-        if ((tidally_locked.eq..true.) .and. (frierson_solar_rad .eq. .true.)) then
+        if ((tidally_locked.eqv..true.) .and. (frierson_solar_rad .eqv. .true.)) then
             call error_mesg( 'socrates_init', &
             'tidally_locked and frierson_solar_rad cannot both be true',FATAL)
         endif
@@ -377,7 +377,7 @@ write(stdlog_unit, socrates_rad_nml)
     n_soc_bands_sw = spectrum_sw%dim%nd_band
     n_soc_bands_sw_hires = spectrum_sw_hires%dim%nd_band
 
-    if (socrates_hires_mode == .True.) then
+    if (socrates_hires_mode .eqv. .True.) then
         allocate(outputted_soc_spectral_olr(size(lonb,1)-1, size(latb,2)-1, n_soc_bands_lw_hires))
     else
         allocate(outputted_soc_spectral_olr(size(lonb,1)-1, size(latb,2)-1, n_soc_bands_lw ))
@@ -456,7 +456,7 @@ write(stdlog_unit, socrates_rad_nml)
 
         ! spectral output currently not available as required axis not present in diag file 
         if (id_soc_spectral_olr > 0) then 
-            if (socrates_hires_mode == .True.) then
+            if (socrates_hires_mode .eqv. .True.) then
                 allocate(spectral_olr_store(size(lonb,1)-1, size(latb,2)-1, n_soc_bands_lw_hires))
             else
                 allocate(spectral_olr_store(size(lonb,1)-1, size(latb,2)-1, n_soc_bands_lw ))
@@ -621,13 +621,13 @@ write(stdlog_unit, socrates_rad_nml)
           input_reff_rad = reshape(fms_reff_rad(:,:,:),(/si*sj,sk /))
           input_mmr_cl_rad = reshape(fms_mmr_cl_rad(:,:,:),(/si*sj,sk/))
 
-          if (account_for_effect_of_water == .true.) then
+          if (account_for_effect_of_water .eqv. .true.) then
               input_mixing_ratio = reshape(fms_spec_hum(:,:,:) / (1. - fms_spec_hum(:,:,:)),(/si*sj,sk /)) !Mass mixing ratio = q / (1-q)
           else
               input_mixing_ratio = 0.0
           endif
           
-          if (account_for_effect_of_ozone == .true.) then
+          if (account_for_effect_of_ozone .eqv. .true.) then
             input_o3_mixing_ratio = reshape(fms_ozone(:,:,:),(/si*sj,sk /))
           else         
             input_o3_mixing_ratio = 0.0
@@ -684,10 +684,10 @@ write(stdlog_unit, socrates_rad_nml)
           soc_heating_rate = 0.0
 
           ! Test if LW or SW mode
-          if (soc_lw_mode == .TRUE.) then
+          if (soc_lw_mode .eqv. .TRUE.) then
              control_lw%isolir = 2
              CALL read_control(control_lw, spectrum_lw, do_cloud_simple)
-             if (socrates_hires_mode == .FALSE.) then
+             if (socrates_hires_mode .eqv. .FALSE.) then
                 control_calc = control_lw
                 spectrum_calc = spectrum_lw
              else
@@ -698,7 +698,7 @@ write(stdlog_unit, socrates_rad_nml)
           else
              control_sw%isolir = 1
              CALL read_control(control_sw, spectrum_sw, do_cloud_simple)
-             if(socrates_hires_mode == .FALSE.) then
+             if(socrates_hires_mode .eqv. .FALSE.) then
                 control_calc = control_sw
                 spectrum_calc = spectrum_sw
              else
@@ -720,7 +720,7 @@ write(stdlog_unit, socrates_rad_nml)
             idx_chunk_start = (i_chunk-1)*chunk_size + 1
             idx_chunk_end   = (i_chunk)*chunk_size
 
-          if (soc_lw_mode==.TRUE.) then
+          if (soc_lw_mode.eqv..TRUE.) then
  
             CALL socrates_calc(Time_diag, control_calc, spectrum_calc,                      &
                n_profile_chunk, n_layer, input_n_cloud_layer, input_n_aer_mode,             &
@@ -802,7 +802,7 @@ write(stdlog_unit, socrates_rad_nml)
           
           output_heating_rate(:,:,:) = reshape(soc_heating_rate(:,:),(/si,sj,sk /))
 
-          if (soc_lw_mode == .TRUE.) then
+          if (soc_lw_mode .eqv. .TRUE.) then
               output_soc_spectral_olr(:,:,:) = reshape(soc_spectral_olr(:,:),(/si,sj,int(n_soc_bands_lw,i_def) /))
           endif
 
@@ -1131,14 +1131,14 @@ subroutine run_socrates(Time, Time_diag, rad_lat, rad_lon, temp_in, q_in, t_surf
       !get ozone 
        if(do_read_ozone)then
          call interpolator( o3_interp, Time_diag, p_half_in, ozone_in, trim(ozone_field_name))
-         if (input_o3_file_is_mmr==.false.) then
+         if (input_o3_file_is_mmr.eqv..false.) then
              ozone_in = ozone_in * wtmozone / (1000. * gas_constant / rdgas ) !Socrates expects all abundances to be mass mixing ratio. So if input file is volume mixing ratio, it must be converted to mass mixing ratio using the molar masses of dry air and ozone
              ! Molar mass of dry air calculated from gas_constant / rdgas, and converted into g/mol from kg/mol by multiplying by 1000. This conversion is necessary because wtmozone is in g/mol.
              
          endif 
        endif
 
-       if (input_co2_mmr==.false.) then
+       if (input_co2_mmr.eqv..false.) then
            co2_in = co2_ppmv * 1.e-6 * wtmco2 / (1000. * gas_constant / rdgas )!Convert co2_ppmv to a mass mixing ratio, as required by socrates
              ! Molar mass of dry air calculated from gas_constant / rdgas, and converted into g/mol from kg/mol by multiplying by 1000. This conversion is necessary because wtmco2 is in g/mol.           
        else
@@ -1148,7 +1148,7 @@ subroutine run_socrates(Time, Time_diag, rad_lat, rad_lon, temp_in, q_in, t_surf
        !get co2 
        if(do_read_co2)then
          call interpolator( co2_interp, Time_diag, p_half_in, co2_in, trim(co2_field_name))
-         if (input_co2_mmr==.false.) then
+         if (input_co2_mmr.eqv..false.) then
              co2_in = co2_in * 1.e-6 * wtmco2 / (1000. * gas_constant / rdgas )
              ! Molar mass of dry air calculated from gas_constant / rdgas, and converted into g/mol from kg/mol by multiplying by 1000. This conversion is necessary because wtmco2 is in g/mol.
              


### PR DESCRIPTION
As described in #221, some of the test cases are failing when run under gfortran. I've identified and fixed two of these 3 issues, and am working on the 3rd. The changes are as follows:

* The axisymmetric case was failing because we were supplying dt_rad as a float when it should have been an integer. Intel didn’t mind this, but gfortran objects.
* The Top down test seg-faulted because one of the loops over the y dimension was looping over the length of the x dimension instead
* I’ve had a look at the giant-planet test case to see if I can see anything obvious. I’ve made a few changes that might help, but I’d need to get a working example of what the problem is before I can make too much progress. 

I'm running the trip tests on these now to see what progress I might have made, but as they all failed previously, this is more just to check that they now run.