### PR TITLE
Adding front-end option to compile Isca using single-precision (only working with Intel compilers)

### DIFF
--- a/exp/test_cases/held_suarez/held_suarez_test_case_single.py
+++ b/exp/test_cases/held_suarez/held_suarez_test_case_single.py
@@ -1,0 +1,110 @@
+import numpy as np
+
+from isca import DryCodeBase, DiagTable, Experiment, Namelist, GFDL_BASE
+
+NCORES = 16
+RESOLUTION = 'T42', 25  # T42 horizontal resolution, 25 levels in pressure
+
+# a CodeBase can be a directory on the computer,
+# useful for iterative development
+cb = DryCodeBase.from_directory(GFDL_BASE)
+
+# or it can point to a specific git repo and commit id.
+# This method should ensure future, independent, reproducibility of results.
+# cb = DryCodeBase.from_repo(repo='https://github.com/isca/isca', commit='isca1.1')
+
+# compilation depends on computer specific settings.  The $GFDL_ENV
+# environment variable is used to determine which `$GFDL_BASE/src/extra/env` file
+# is used to load the correct compilers.  The env file is always loaded from
+# $GFDL_BASE and not the checked out git repo.
+cb.use_single_precision()
+
+cb.compile()  # compile the source code to working directory $GFDL_WORK/codebase
+
+# create an Experiment object to handle the configuration of model parameters
+# and output diagnostics
+
+exp_name = 'held_suarez_default_single_precision'
+exp = Experiment(exp_name, codebase=cb)
+
+#Tell model how to write diagnostics
+diag = DiagTable()
+diag.add_file('atmos_monthly', 30, 'days', time_units='days')
+
+#Tell model which diagnostics to write
+diag.add_field('dynamics', 'ps', time_avg=True)
+diag.add_field('dynamics', 'bk')
+diag.add_field('dynamics', 'pk')
+diag.add_field('dynamics', 'ucomp', time_avg=True)
+diag.add_field('dynamics', 'vcomp', time_avg=True)
+diag.add_field('dynamics', 'temp', time_avg=True)
+diag.add_field('dynamics', 'vor', time_avg=True)
+diag.add_field('dynamics', 'div', time_avg=True)
+
+exp.diag_table = diag
+
+# define namelist values as python dictionary
+# wrapped as a namelist object.
+namelist = Namelist({
+    'main_nml': {
+        'dt_atmos': 600,
+        'days': 30,
+        'calendar': 'thirty_day',
+        'current_date': [2000,1,1,0,0,0]
+    },
+
+    'atmosphere_nml': {
+        'idealized_moist_model': False  # False for Newtonian Cooling.  True for Isca/Frierson
+    },
+
+    'spectral_dynamics_nml': {
+        'damping_order'           : 4,                      # default: 2
+        'water_correction_limit'  : 200.e2,                 # default: 0
+        'reference_sea_level_press': 1.0e5,                  # default: 101325
+        'valid_range_t'           : [100., 800.],           # default: (100, 500)
+        'initial_sphum'           : 0.0,                  # default: 0
+        'vert_coord_option'       : 'uneven_sigma',         # default: 'even_sigma'
+        'scale_heights': 6.0,
+        'exponent': 7.5,
+        'surf_res': 0.5
+    },
+
+    # configure the relaxation profile
+    'hs_forcing_nml': {
+        't_zero': 315.,    # temperature at reference pressure at equator (default 315K)
+        't_strat': 200.,   # stratosphere temperature (default 200K)
+        'delh': 60.,       # equator-pole temp gradient (default 60K)
+        'delv': 10.,       # lapse rate (default 10K)
+        'eps': 0.,         # stratospheric latitudinal variation (default 0K)
+        'sigma_b': 0.7,    # boundary layer friction height (default p/ps = sigma = 0.7)
+
+        # negative sign is a flag indicating that the units are days
+        'ka':   -40.,      # Constant Newtonian cooling timescale (default 40 days)
+        'ks':    -4.,      # Boundary layer dependent cooling timescale (default 4 days)
+        'kf':   -1.,       # BL momentum frictional timescale (default 1 days)
+
+        'do_conserve_energy':   True,  # convert dissipated momentum into heat (default True)
+    },
+
+    'diag_manager_nml': {
+        'mix_snapshot_average_fields': False
+    },
+
+    'fms_nml': {
+        'domains_stack_size': 600000                        # default: 0
+    },
+
+    'fms_io_nml': {
+        'threading_write': 'single',                         # default: multi
+        'fileset_write': 'single',                           # default: multi
+    }
+})
+
+exp.namelist = namelist
+exp.set_resolution(*RESOLUTION)
+
+#Lets do a run!
+if __name__ == '__main__':
+    exp.run(1, num_cores=NCORES, use_restart=False)
+    for i in range(2, 13):
+        exp.run(i, num_cores=NCORES)  # use the restart i-1 by default

--- a/src/extra/python/isca/codebase.py
+++ b/src/extra/python/isca/codebase.py
@@ -120,6 +120,7 @@ class CodeBase(Logger):
         # read path names from the default file
         self.path_names = []
         self.compile_flags = []  # users can append to this to add additional compiler options
+        self.precision_compile_flags = ['-DOVERLOAD_C8'] #Default is to use double precision. User can change to single precision using cb.use_single_precision() before compile step 
 
     @property
     def code_is_available(self):
@@ -255,6 +256,7 @@ class CodeBase(Logger):
         #     compile_flags.append('-O%d' % optimisation)
 
         compile_flags.extend(self.compile_flags)
+        compile_flags.extend(self.precision_compile_flags)        
         compile_flags_str = ' '.join(compile_flags)
 
         # get path_names from the directory
@@ -281,6 +283,12 @@ class CodeBase(Logger):
             self._log_line(line)
 
         self.log.info('Compilation complete.')
+
+    def use_single_precision(self):
+            self.log.info('Going to use single_precision')
+            self.precision_compile_flags = ['-DOVERLOAD_C4', '-DOVERLOAD_R4']
+            self.executable_name = self.executable_name.strip('.x')+'_single.x'
+            self.builddir = P(self.workdir, 'build', self.executable_name.split('.')[0])
 
 
 

--- a/src/extra/python/isca/templates/compile.sh
+++ b/src/extra/python/isca/templates/compile.sh
@@ -53,13 +53,13 @@ if [ $debug == True ]; then
  echo "Compiling in debug mode"
 
 # execute mkmf to create makefile
-cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 {{compile_flags}}"
+cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NM {{compile_flags}}"
 $mkmf  -a $sourcedir -t $template_debug -p $executable -c "$cppDefs" $pathnames $sourcedir/shared/include $sourcedir/shared/mpp/include
 
 else
 
 # execute mkmf to create makefile
-cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 {{compile_flags}}"
+cppDefs="-Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NM {{compile_flags}}"
 $mkmf  -a $sourcedir -t $template -p $executable -c "$cppDefs" $pathnames $sourcedir/shared/include $sourcedir/shared/mpp/include
 
 fi


### PR DESCRIPTION
We want to be able to run Isca using single-precision arithmetic, rather than the default double precision. This p/r mirrors some code I wrote way back in 2020:
https://github.com/sit23/Isca/commit/efd019566e6c822a93564a3e7371dc2d4c3de404

This change gives a method on the codebase object to allow the compile flags to be set to do single precision arithmetic, rather then double, but leaves double as the default. 

I've added a new held-suarez test case to show how this method is to be used.

N.B. this only works at the moment for Intel compilation.