### PR TITLE
Getting Isca to work on Exeter's HPC using Intel compilers, and fixing gettid error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Conda for OS ${{ matrix.os }} and Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment-py${{ matrix.python-version }}_frozen.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,14 +40,13 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Conda for OS ${{ matrix.os }} and Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: ci/environment-py${{ matrix.python-version }}_frozen.yml
-          miniforge-variant: Mambaforge
           miniforge-version: "latest"
           use-mamba: true
           activate-environment: isca_env

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -78,15 +78,25 @@ $ cd Isca
 
 3. **Create a conda environment**
 
-Requirements for Isca can be installed via the .yml file included with the model in `Isca/ci/environment-py3.12_frozen.yml`
-Navigate to the downloaded Isca folder, and create a conda environment `isca_env` containing the required packages using: 
+Requirements for Isca can be installed via the .yml files included with the model in `Isca/ci/`. The choice of which yml file depends on your system:
+
+Both the `environment-py3.12_frozen.yml` and `environment-py.yml` files install everything required to install Isca, including the gfortran compilers and netcdf-fortran. The `environment-py3.12_frozen.yml` file has frozen versions of all the packages that we ourselves have tested, whereas the `environment-py.yml` file will grab the latest versions of all of these libraries etc. 
+
+The `environment-py_no_compilers.yml` version includes only the packages needed by Isca without the gfortran compilers and netcdf-fortran. This is the option to choose if you want to install Isca on a system that already has a fortran compiler, MPI and netcdf-fortran already installed. 
+
+Once you've decided on the yml file to use, you should navigate to the downloaded Isca folder, and create a conda environment `isca_env` containing the required packages using: 
 ```{bash}
-$ conda env create -f ci/environment-py3.12_frozen.yml
+$ conda env create -f ci/YML_FILE_THAT_YOU_CHOSE.yml
 ```
 Then activate the environment; you'll need to do this each time you launch a new bash session.
 ```{bash}
 $ conda activate isca_env
 ```
+or
+```{bash}
+$ conda activate isca_env_no_comp
+``` 
+if you chose the no-compilers yml file.
 
 4. **Install the model**
 
@@ -121,7 +131,7 @@ The value of `GFDL_ENV` corresponds to a file in `src/extra/env` that is sourced
 
 You may wish to configure your own way to run Isca using locally available compilers, e.g. the Intel compilers. An example using such a setup is available here - `src/extra/env/emps-gv`.
 
-At Exeter University, Isca is compiled using:
+At the University of Exeter, Isca is compiled using:
 
 * Intel Compiler Suite 14.0
 * OpenMPI 10.0.1

--- a/ci/environment-py_no_compilers.yml
+++ b/ci/environment-py_no_compilers.yml
@@ -1,0 +1,16 @@
+name: isca_env_no_comp
+channels:
+- conda-forge
+dependencies:
+- dask
+- f90nml
+- ipykernel
+- jinja2
+- numpy
+- pandas
+- python
+- pip
+- pytest
+- sh
+- tqdm
+- xarray

--- a/src/extra/env/isca_intel_2021
+++ b/src/extra/env/isca_intel_2021
@@ -1,0 +1,8 @@
+echo loadmodules for Isca
+
+export F90=mpiifort
+export CC=mpicc
+
+module purge
+module load intel-compilers/2021.4.0
+module load netCDF-Fortran/4.5.3-iimpi-2021b

--- a/src/shared/mpp/affinity.c
+++ b/src/shared/mpp/affinity.c
@@ -28,12 +28,17 @@
 #include <sched.h>
 #include <errno.h>
 #include <sys/resource.h>
-#include <sys/syscall.h>
 
-static pid_t gettid(void)
-{
-  return syscall(__NR_gettid);
-}
+#if !defined(_GNU_SOURCE) || !defined(__GLIBC__) || __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 30)
+#include <sys/syscall.h>
+static
+pid_t gettid ( void )
+ {
+   return syscall(__NR_gettid);
+ }
+#endif
+
+
 
 /*
  * Returns this thread's CPU affinity, if bound to a single core,


### PR DESCRIPTION
The University of Exeter's HPC (also called Isca) has recently updated, and many of the older Intel fortran compilers no longer work. This P/R creates a new env file that uses the Intel 2021 compilers to run Isca, and this works well. 

Once I'd identified the correct compilers to use, I got the following error:

```
2025-04-29 12:52:56,407 - isca - INFO - mpicc -Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DINTERNAL_FILE_NML -DOVERLOAD_C8 -DRRTM_NO_COMPILE -DSOC_NO_COMPILE -I/usr/local/include -D__IFC  -c	/gpfs/ts0/projects/Research_Project-161613/sit204/workdir_isca_intel_2017_2025/codebase/_gpfs_ts0_home_sit204_Isca_/code/src/shared/mpp/affinity.c
2025-04-29 12:52:56,470 - isca - INFO - /gpfs/ts0/projects/Research_Project-161613/sit204/workdir_isca_intel_2017_2025/codebase/_gpfs_ts0_home_sit204_Isca_/code/src/shared/mpp/affinity.c:33:14: error: static declaration of ‘gettid’ follows non-static declaration
2025-04-29 12:52:56,470 - isca - INFO - 33 | static pid_t gettid(void)
2025-04-29 12:52:56,470 - isca - INFO - |              ^~~~~~
2025-04-29 12:52:56,470 - isca - INFO - In file included from /usr/include/unistd.h:1208,
2025-04-29 12:52:56,470 - isca - INFO - from /gpfs/ts0/projects/Research_Project-161613/sit204/workdir_isca_intel_2017_2025/codebase/_gpfs_ts0_home_sit204_Isca_/code/src/shared/mpp/affinity.c:27:
2025-04-29 12:52:56,470 - isca - INFO - /usr/include/bits/unistd_ext.h:34:16: note: previous declaration of ‘gettid’ with type ‘__pid_t(void)’ {aka ‘int(void)’}
2025-04-29 12:52:56,470 - isca - INFO - 34 | extern __pid_t gettid (void) __THROW;
2025-04-29 12:52:56,470 - isca - INFO - |                ^~~~~~
2025-04-29 12:52:56,474 - isca - INFO - make: *** [Makefile:17: affinity.o] Error 1
2025-04-29 12:52:56,475 - isca - INFO - ERROR: mkmf failed for held_suarez.x
```

This is a well-known problem associated with versions of glibc > 2.30, which the new system now has. The fix is copied from the same fix to MOM5 applied here https://github.com/mom-ocean/MOM5/pull/346. 

The third contribution of this P/R is to include in the ci folder a no-compiler yml file, which installs only the components needed for Isca on the assumption that the Fortran compiler, NETCDF-Fortran and MPI are already available. This will be more common for people working in HPC environments than having to install all the compilers, as both the previous yml files have done. I have updated the README to reflect these new options.