### PR TITLE
Getting python version in docs into line with ci.

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - numpy
 - openmpi
 - pandas
-- python=3.9
+- python=3.12
 - pip
 - pytest
 - sh


### PR DESCRIPTION
Ci for docs now fails because of the ci requesting python 3.12 and the docs requesting 3.9. Updating to 3.12 to get both in to line with eachother.