### PR TITLE
Fix missing comma in json_logging FORMAT statements in spectral_dynamics.F90

### DIFF
--- a/src/atmos_spectral/model/spectral_dynamics.F90
+++ b/src/atmos_spectral/model/spectral_dynamics.F90
@@ -1905,9 +1905,9 @@ endif
 100 format(' Integration completed through',i6,' days',i6,' seconds')
 200 format(' Integration completed through',i5,a4,i3,2x,i2,':',i2,':',i2)
 300 format(1x, '{"day":',i6,2x,',"second":', i6, &
-    2x,',"max_speed":',e13.6,3x,',"avg_T":',e13.6, 3x '}')
+    2x,',"max_speed":',e13.6,3x,',"avg_T":',e13.6, 3x,'}')
 400 format(1x, '{"date": "',i0.4,'-',i0.2,'-',i0.2, &
-  '", "time": "', i0.2,':', i0.2,':', i0.2, '", "max_speed":',f6.1,3x,',"avg_T":',f6.1, 3x '}')
+  '", "time": "', i0.2,':', i0.2,':', i0.2, '", "max_speed":',f6.1,3x,',"avg_T":',f6.1, 3x,'}')
 
 end subroutine global_integrals
 !===================================================================================


### PR DESCRIPTION
Format labels 300 and 400 both ended with `3x '}'`, missing the comma between the 3x edit descriptor and the '}' character literal. Older/other compilers tolerated this, but a strict gfortran build fails at runtime with "Fortran runtime error: Missing comma between descriptors" as soon as json_logging is enabled (spectral_dynamics_nml). This is force-enabled by isca.util.exp_progress, which the trip_test framework uses for its progress bar, so any run through trip_test_command_line crashes on this toolchain regardless of which commit is being tested.