### PR TITLE
Mars test case patch

### DIFF
--- a/exp/test_cases/socrates_mars/socrates_mars_test_case.py
+++ b/exp/test_cases/socrates_mars/socrates_mars_test_case.py
@@ -148,7 +148,7 @@ exp.namelist = namelist = Namelist({
     'sat_vapor_pres_nml': {
         'do_simple':True,
         'tcmin':  -223, #Make sure low temperature limit of saturation vapour pressure is low enough that it doesn't cause an error (this planet has no moisture anyway, so doesn't directly affect the calculation).
-        'tcmax': 350.,
+        'tcmax': 350, # NOTE: tcmin/tcmax are Fortran INTEGERs (sat_vapor_pres.F90) - a trailing '.' here makes this a Python float, which gfortran correctly rejects as a namelist type mismatch (FATAL "Unknown namelist, or mistyped namelist variable in namelist sat_vapor_pres_nml"). Keep this as an int.
     },
 
     'damping_driver_nml': {


### PR DESCRIPTION
Fix socrates_mars_test_case.py crashing at startup on tcmax type mismatch

sat_vapor_pres.F90 declares tcmin/tcmax as INTEGER, but this test case set tcmax with a trailing '.' (350.), making it a Python float that Isca's namelist serializer writes out as 350.0. gfortran correctly rejects assigning a real literal to a declared-integer namelist variable, which FMS's check_nml_error surfaces as:

  FATAL from PE 0: check_nml_error in fms_mod: Unknown namelist, or
  mistyped namelist variable in namelist sat_vapor_pres_nml, (IOSTAT = 5010)

This crashed the run before the first timestep. tcmin (set without a trailing '.', so already an int) was unaffected. Confirmed by bisecting input.nml block by block and then individual assignments within sat_vapor_pres_nml, and cross-checked against grey_mars_test_case.py, which sets tcmax as a plain int and has never hit this.

This test case is commented out of the default trip_test run (for the separate, unrelated reason that its Socrates spectral files aren't included in the repo), which is presumably why this has gone unnoticed - it doesn't look like it's actually been run to completion before.